### PR TITLE
fix: jwt 검증 과정 커스텀

### DIFF
--- a/BE/layover/src/custom-exception.ts
+++ b/BE/layover/src/custom-exception.ts
@@ -10,6 +10,8 @@ import { Response } from 'express';
 
 export const enum CustomCode {
   'OAUTH01' = 'OAUTH01',
+  'JWT01' = 'JWT01',
+  'JWT02' = 'JWT02',
   'NEST_OFFER' = 'NEST_OFFER',
   'INTERNAL_SERVER_ERROR' = 'INTERNAL_SERVER_ERROR',
 }
@@ -20,6 +22,18 @@ export class ECustomException extends EnumType<ECustomException>() {
     HttpStatus.UNAUTHORIZED,
     CustomCode.OAUTH01,
     '회원가입이 되지 않은 유저입니다.',
+  );
+
+  static readonly JWT01 = new ECustomException(
+    HttpStatus.UNAUTHORIZED,
+    CustomCode.JWT01,
+    '유효하지 않은 토큰입니다.',
+  );
+
+  static readonly JWT02 = new ECustomException(
+    HttpStatus.UNAUTHORIZED,
+    CustomCode.JWT02,
+    '토큰 만료기간이 경과하였습니다.',
   );
 
   private constructor(

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -47,7 +47,6 @@ export class OauthController {
     @Body('username') username: string,
     @Body('provider') provider: string,
   ) {
-    console.log(memberHash, username, provider);
     await this.oauthService.signup(memberHash, username, provider);
 
     // login
@@ -60,8 +59,13 @@ export class OauthController {
   @Post('refresh-token')
   async renewTokens(@Body('refreshToken') refreshToken: string) {
     // validate refresh token
-    const payload = await this.oauthService.validateJWT(refreshToken);
+    await this.oauthService.validateJWT(
+      refreshToken,
+      process.env.LAYOVER_PUBLIC_IP,
+    );
+    const payload = await this.oauthService.extractPayloadJWT(refreshToken);
 
+    console.log(payload);
     // 새로운 토큰을 생성하고 이를 반환함
     const { accessJWT, refreshJWT } =
       await this.oauthService.generateAccessRefreshTokens(payload.memberHash);

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -63,9 +63,8 @@ export class OauthController {
     const payload = await this.oauthService.validateJWT(refreshToken);
 
     // 새로운 토큰을 생성하고 이를 반환함
-    const { accessJWT, refreshJWT } = await this.oauthService.login(
-      payload.memberHash,
-    );
+    const { accessJWT, refreshJWT } =
+      await this.oauthService.generateAccessRefreshTokens(payload.memberHash);
 
     // return access token and refresh token
     return { accessToken: accessJWT, refreshToken: refreshJWT };

--- a/BE/layover/src/oauth/oauth.service.ts
+++ b/BE/layover/src/oauth/oauth.service.ts
@@ -64,6 +64,13 @@ export class OauthService {
       // response 401, OAUTH01
     }
 
+    // 각 토큰 반환
+    return this.generateAccessRefreshTokens(memberHash);
+  }
+
+  async generateAccessRefreshTokens(
+    memberHash: string,
+  ): Promise<{ accessJWT: string; refreshJWT: string }> {
     // access token 생성
     const accessTokenPaylaod = makeJwtPaylaod('access', memberHash);
     const accessJWT = await this.jwtService.signAsync(accessTokenPaylaod);

--- a/BE/layover/src/utils/hashUtils.ts
+++ b/BE/layover/src/utils/hashUtils.ts
@@ -1,7 +1,15 @@
-import { createHash } from 'crypto';
+import { createHash, createHmac } from 'crypto';
 
 export function hashSHA256(input: string): string {
   const hash = createHash('sha256');
   hash.update(input);
   return hash.digest('hex');
+}
+
+export function hashHMACSHA256(message: string, secret: string): string {
+  const hmac = createHmac('sha256', secret);
+  hmac.update(message);
+
+  const signature = hmac.digest('base64url');
+  return signature;
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 토큰 생성 함수를 따로 분리
- jwt 검증 과정 커스텀

#### 📌 변경 사항
- 토큰 생성 함수를 별도로 만듦. generateAccessRefreshTokens()
- jwt 검증을 그냥 `verifyAsync()` 함수로 했었는데, 이를 별도로 구현하여 사용. jwt 관련 예외를 세분화 하기 위함.


#### Linked Issue
#22 
