### PR TITLE
feat: 반복 재생이 되는 LoopingPlayerView 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		835A61A02B068115002F22A5 /* PlaybackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619A2B068115002F22A5 /* PlaybackModels.swift */; };
 		835A61A12B068115002F22A5 /* PlaybackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619B2B068115002F22A5 /* PlaybackViewController.swift */; };
 		835A61A22B068115002F22A5 /* PlaybackInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619C2B068115002F22A5 /* PlaybackInteractor.swift */; };
+		19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */; };
 		FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC25119F2B045C0A004717BC /* SignUpInteractor.swift */; };
 		FC2511A22B045C3F004717BC /* SignUpPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511A12B045C3F004717BC /* SignUpPresenter.swift */; };
 		FC2511A42B045D6C004717BC /* SignUpModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511A32B045D6C004717BC /* SignUpModels.swift */; };
@@ -123,6 +124,7 @@
 		835A619A2B068115002F22A5 /* PlaybackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackModels.swift; sourceTree = "<group>"; };
 		835A619B2B068115002F22A5 /* PlaybackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackViewController.swift; sourceTree = "<group>"; };
 		835A619C2B068115002F22A5 /* PlaybackInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackInteractor.swift; sourceTree = "<group>"; };
+		19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopingPlayerView.swift; sourceTree = "<group>"; };
 		FC25119F2B045C0A004717BC /* SignUpInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInteractor.swift; sourceTree = "<group>"; };
 		FC2511A12B045C3F004717BC /* SignUpPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPresenter.swift; sourceTree = "<group>"; };
 		FC2511A32B045D6C004717BC /* SignUpModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpModels.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				19743C042B06940D001E405A /* PlayerView.swift */,
+				19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -614,6 +617,7 @@
 				FCEE0FFA2B03AF8500195BBE /* SignUpViewController.swift in Sources */,
 				194551F32B037F2D00299768 /* LoginWorker.swift in Sources */,
 				835A61902B067D61002F22A5 /* LOSlider.swift in Sources */,
+				19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */,
 				FC7E45942AFF7486004F155A /* DummyDesignSystem.swift in Sources */,
 				194551F72B037F2D00299768 /* LoginInteractor.swift in Sources */,
 				FC7E453C2AFEB623004F155A /* SceneDelegate.swift in Sources */,

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -57,7 +57,7 @@ final class LoopingPlayerView: UIView {
 
 #Preview {
     let view = LoopingPlayerView()
-    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, timeRange: .init(start: .zero, end: .init(seconds: 3.0, preferredTimescale: .max)))
+    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, timeRange: .init(start: .zero, end: .init(seconds: 3.0, preferredTimescale: CMTimeScale(1.0))))
     view.play()
     view.player?.isMuted = true
     return view

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -15,7 +15,7 @@ final class LoopingPlayerView: UIView {
 
     override static var layerClass: AnyClass { AVPlayerLayer.self }
 
-    var player: AVQueuePlayer? {
+    private(set) var player: AVQueuePlayer? {
         get { playerLayer?.player as? AVQueuePlayer }
         set { playerLayer?.player = newValue }
     }
@@ -57,7 +57,9 @@ final class LoopingPlayerView: UIView {
 
 #Preview {
     let view = LoopingPlayerView()
-    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, timeRange: .init(start: .zero, end: .init(seconds: 3.0, preferredTimescale: CMTimeScale(1.0))))
+    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, 
+                      timeRange: .init(start: .zero,
+                                       end: .init(seconds: 3.0, preferredTimescale: CMTimeScale(1.0))))
     view.play()
     view.player?.isMuted = true
     return view

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -1,0 +1,64 @@
+//
+//  LoopingPlayerView.swift
+//  Layover
+//
+//  Created by 김인환 on 11/20/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+import AVFoundation
+
+final class LoopingPlayerView: UIView {
+
+    // MARK: - Properties
+
+    override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+    var player: AVQueuePlayer? {
+        get { playerLayer?.player as? AVQueuePlayer }
+        set { playerLayer?.player = newValue }
+    }
+
+    private var looper: AVPlayerLooper?
+
+    private var playerLayer: AVPlayerLayer? { layer as? AVPlayerLayer }
+
+    // MARK: - View Life Cycle
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        playerLayer?.frame = bounds
+    }
+
+    // MARK: - Methods
+
+    func prepareVideo(with url: URL, timeRange: CMTimeRange) {
+        let playerItem = AVPlayerItem(url: url)
+        let player = AVQueuePlayer(playerItem: playerItem)
+        looper = AVPlayerLooper(player: player, templateItem: playerItem, timeRange: timeRange)
+        self.player = player
+    }
+
+    func disable() {
+        player?.pause()
+        player = nil
+        looper = nil
+    }
+
+    func play() {
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+}
+
+#Preview {
+    let view = LoopingPlayerView()
+    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, timeRange: .init(start: .zero, end: .init(seconds: 3.0, preferredTimescale: .max)))
+    view.play()
+    view.player?.isMuted = true
+    return view
+}


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
반복 재생을 위한 LoopingPlayerView를 구현했습니다.
반복 재생은 따로 AVPlayerLooper로 감싸주어야 하더군요
사용 방법은 프리뷰 코드를 참고하시면 되겠습니다.
```swift
#Preview {
    let view = LoopingPlayerView()
    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, timeRange: .init(start: .zero, end: .init(seconds: 3.0, preferredTimescale: CMTimeScale(1.0))))
    view.play()
    view.player?.isMuted = true
    return view
}
```

##### 📸 ScreenShot
작동, 구현화면
<img width=40% alt="image" src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/d962361f-e161-4a1a-9d07-72610f24bba3">

#### Linked Issue
close #36 
