### PR TITLE
feat: LayoverConstraintWrapper 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -31,8 +31,11 @@
 		194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */; };
 		1945523B2B05258200299768 /* HomeConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1945523A2B05258200299768 /* HomeConfigurator.swift */; };
 		19743C052B06940D001E405A /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19743C042B06940D001E405A /* PlayerView.swift */; };
+		19ABC1C32B0B78C800736813 /* LayoverConstraintWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC1C22B0B78C800736813 /* LayoverConstraintWrapper.swift */; };
+		19ABC1C52B0B7D0100736813 /* LayoverConstraintWrapper+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC1C42B0B7D0100736813 /* LayoverConstraintWrapper+UIView.swift */; };
 		19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFCD2B02410F003B35F2 /* AuthManager.swift */; };
 		19C7AFD62B02584D003B35F2 /* KeychainStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFD52B02584D003B35F2 /* KeychainStored.swift */; };
+		19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */; };
 		835A61902B067D61002F22A5 /* LOSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A618F2B067D61002F22A5 /* LOSlider.swift */; };
 		835A61922B067FEC002F22A5 /* LOTagStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A61912B067FEC002F22A5 /* LOTagStackView.swift */; };
 		835A61942B068096002F22A5 /* LODescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A61932B068096002F22A5 /* LODescriptionView.swift */; };
@@ -42,7 +45,6 @@
 		835A61A02B068115002F22A5 /* PlaybackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619A2B068115002F22A5 /* PlaybackModels.swift */; };
 		835A61A12B068115002F22A5 /* PlaybackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619B2B068115002F22A5 /* PlaybackViewController.swift */; };
 		835A61A22B068115002F22A5 /* PlaybackInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A619C2B068115002F22A5 /* PlaybackInteractor.swift */; };
-		19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */; };
 		FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC25119F2B045C0A004717BC /* SignUpInteractor.swift */; };
 		FC2511A22B045C3F004717BC /* SignUpPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511A12B045C3F004717BC /* SignUpPresenter.swift */; };
 		FC2511A42B045D6C004717BC /* SignUpModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511A32B045D6C004717BC /* SignUpModels.swift */; };
@@ -115,8 +117,11 @@
 		194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
 		1945523A2B05258200299768 /* HomeConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeConfigurator.swift; sourceTree = "<group>"; };
 		19743C042B06940D001E405A /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		19ABC1C22B0B78C800736813 /* LayoverConstraintWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoverConstraintWrapper.swift; sourceTree = "<group>"; };
+		19ABC1C42B0B7D0100736813 /* LayoverConstraintWrapper+UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LayoverConstraintWrapper+UIView.swift"; sourceTree = "<group>"; };
 		19C7AFCD2B02410F003B35F2 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		19C7AFD52B02584D003B35F2 /* KeychainStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStored.swift; sourceTree = "<group>"; };
+		19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopingPlayerView.swift; sourceTree = "<group>"; };
 		835A618F2B067D61002F22A5 /* LOSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOSlider.swift; sourceTree = "<group>"; };
 		835A61912B067FEC002F22A5 /* LOTagStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOTagStackView.swift; sourceTree = "<group>"; };
 		835A61932B068096002F22A5 /* LODescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LODescriptionView.swift; sourceTree = "<group>"; };
@@ -126,7 +131,6 @@
 		835A619A2B068115002F22A5 /* PlaybackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackModels.swift; sourceTree = "<group>"; };
 		835A619B2B068115002F22A5 /* PlaybackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackViewController.swift; sourceTree = "<group>"; };
 		835A619C2B068115002F22A5 /* PlaybackInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackInteractor.swift; sourceTree = "<group>"; };
-		19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopingPlayerView.swift; sourceTree = "<group>"; };
 		FC25119F2B045C0A004717BC /* SignUpInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInteractor.swift; sourceTree = "<group>"; };
 		FC2511A12B045C3F004717BC /* SignUpPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPresenter.swift; sourceTree = "<group>"; };
 		FC2511A32B045D6C004717BC /* SignUpModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpModels.swift; sourceTree = "<group>"; };
@@ -231,6 +235,15 @@
 				194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		19ABC1C62B0B8A5B00736813 /* LayoverConstraint */ = {
+			isa = PBXGroup;
+			children = (
+				19ABC1C22B0B78C800736813 /* LayoverConstraintWrapper.swift */,
+				19ABC1C42B0B7D0100736813 /* LayoverConstraintWrapper+UIView.swift */,
+			);
+			path = LayoverConstraint;
 			sourceTree = "<group>";
 		};
 		19BB8A572B07BEE30070B922 /* UIComponents */ = {
@@ -429,6 +442,7 @@
 		FC7E45812AFF6FF9004F155A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				19ABC1C62B0B8A5B00736813 /* LayoverConstraint */,
 				FC7E45952AFF7497004F155A /* DummyExtension.swift */,
 				FC4975982B03439000D8627F /* UIFont+.swift */,
 				194552012B038B8300299768 /* OSLog+.swift */,
@@ -617,12 +631,14 @@
 				835A61922B067FEC002F22A5 /* LOTagStackView.swift in Sources */,
 				FC7E45902AFF746E004F155A /* DummyWorker.swift in Sources */,
 				835A61A12B068115002F22A5 /* PlaybackViewController.swift in Sources */,
+				19ABC1C32B0B78C800736813 /* LayoverConstraintWrapper.swift in Sources */,
 				1945520F2B03AEA400299768 /* Configurator.swift in Sources */,
 				835A619F2B068115002F22A5 /* PlaybackRouter.swift in Sources */,
 				FC2511B12B04EAEC004717BC /* MapModels.swift in Sources */,
 				FC68E29F2B023315001AABFF /* HTTPMethod.swift in Sources */,
 				835A619D2B068115002F22A5 /* PlaybackPresenter.swift in Sources */,
 				FCEE0FFA2B03AF8500195BBE /* SignUpViewController.swift in Sources */,
+				19ABC1C52B0B7D0100736813 /* LayoverConstraintWrapper+UIView.swift in Sources */,
 				194551F32B037F2D00299768 /* LoginWorker.swift in Sources */,
 				835A61902B067D61002F22A5 /* LOSlider.swift in Sources */,
 				19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */,

--- a/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
+++ b/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
@@ -65,6 +65,14 @@ final class ConstraintMaker {
         trailingAnchor(equalTo: relativeView.trailingAnchor)
     }
 
+    func centerXAnchor(equalTo anchor: NSLayoutAnchor<NSLayoutXAxisAnchor>) {
+        view.centerXAnchor.constraint(equalTo: anchor).isActive = true
+    }
+
+    func centerYAnchor(equalTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>) {
+        view.centerYAnchor.constraint(equalTo: anchor).isActive = true
+    }
+
     func equalToSuperView() {
         guard let superview = view.superview else { return }
         verticalAnchor(equalTo: superview)

--- a/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
+++ b/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
@@ -17,65 +17,139 @@ extension LayoverConstraintWrapper where Base: UIView {
 }
 
 final class ConstraintMaker {
-    let view: UIView
+
+    // MARK: Properties
+
+    private let view: UIView
+
+    var edges: ConstraintEdges {
+        ConstraintEdges(view)
+    }
+
+    var top: ConstraintEdges {
+        ConstraintEdges(view).top
+    }
+
+    var bottom: ConstraintEdges {
+        ConstraintEdges(view).bottom
+    }
+
+    var leading: ConstraintEdges {
+        ConstraintEdges(view).leading
+    }
+
+    var trailing: ConstraintEdges {
+        ConstraintEdges(view).trailing
+    }
+
+    var width: ConstraintEdges {
+        ConstraintEdges(view).width
+    }
+
+    var height: ConstraintEdges {
+        ConstraintEdges(view).height
+    }
+
+    var centerX: ConstraintEdges {
+        ConstraintEdges(view).centerX
+    }
+
+    var centerY: ConstraintEdges {
+        ConstraintEdges(view).centerY
+    }
+
+    var center: ConstraintEdges {
+        ConstraintEdges(view).center
+    }
+
+    // MARK: Initializer
+
+    init(_ view: UIView) {
+        self.view = view
+    }
+}
+
+final class ConstraintEdges {
+
+    // MARK: Properties
+
+    private let view: UIView
+
+    private var topAnchor: NSLayoutYAxisAnchor?
+    private var leadingAnchor: NSLayoutXAxisAnchor?
+    private var trailingAnchor: NSLayoutXAxisAnchor?
+    private var bottomAnchor: NSLayoutYAxisAnchor?
+
+    private var widthAnchor: NSLayoutDimension?
+    private var heightAnchor: NSLayoutDimension?
+
+    private var centerXAnchor: NSLayoutXAxisAnchor?
+    private var centerYAnchor: NSLayoutYAxisAnchor?
+
+    // MARK: Builder Pattern Properties
+
+    var top: ConstraintEdges {
+        topAnchor = view.topAnchor
+        return self
+    }
+
+    var leading: ConstraintEdges {
+        leadingAnchor = view.leadingAnchor
+        return self
+    }
+
+    var trailing: ConstraintEdges {
+        trailingAnchor = view.trailingAnchor
+        return self
+    }
+
+    var bottom: ConstraintEdges {
+        bottomAnchor = view.bottomAnchor
+        return self
+    }
+
+    var width: ConstraintEdges {
+        widthAnchor = view.widthAnchor
+        return self
+    }
+
+    var height: ConstraintEdges {
+        heightAnchor = view.heightAnchor
+        return self
+    }
+
+    var centerX: ConstraintEdges {
+        centerXAnchor = view.centerXAnchor
+        return self
+    }
+
+    var centerY: ConstraintEdges {
+        centerYAnchor = view.centerYAnchor
+        return self
+    }
+
+    var center: ConstraintEdges {
+        centerXAnchor = view.centerXAnchor
+        centerYAnchor = view.centerYAnchor
+        return self
+    }
+
+    // MARK: Intializer
 
     init(_ view: UIView) {
         self.view = view
     }
 
-    func topAnchor(equalTo anchor: NSLayoutYAxisAnchor, constant: CGFloat = 0) {
-        view.topAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
-    }
-
-    func bottomAnchor(equalTo anchor: NSLayoutYAxisAnchor, constant: CGFloat = 0) {
-        view.bottomAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
-    }
-
-    func leadingAnchor(equalTo anchor: NSLayoutXAxisAnchor, constant: CGFloat = 0) {
-        view.leadingAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
-    }
-
-    func trailingAnchor(equalTo anchor: NSLayoutXAxisAnchor, constant: CGFloat = 0) {
-        view.trailingAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
-    }
-
-    func widthAnchor(equalToConstant constant: CGFloat) {
-        view.widthAnchor.constraint(equalToConstant: constant).isActive = true
-    }
-
-    func widthAnchor(equalTo anchor: NSLayoutDimension, multiplier: CGFloat = 1.0) {
-        view.widthAnchor.constraint(equalTo: anchor, multiplier: multiplier).isActive = true
-    }
-
-    func heightAnchor(equalToConstant constant: CGFloat) {
-        view.heightAnchor.constraint(equalToConstant: constant).isActive = true
-    }
-
-    func heightAnchor(equalTo anchor: NSLayoutDimension, multiplier: CGFloat = 1.0) {
-        view.heightAnchor.constraint(equalTo: anchor, multiplier: multiplier).isActive = true
-    }
-
-    func verticalAnchor(equalTo relativeView: UIView) {
-        topAnchor(equalTo: relativeView.topAnchor)
-        bottomAnchor(equalTo: relativeView.bottomAnchor)
-    }
-
-    func horizontalAnchor(equalTo relativeView: UIView) {
-        leadingAnchor(equalTo: relativeView.leadingAnchor)
-        trailingAnchor(equalTo: relativeView.trailingAnchor)
-    }
-
-    func centerXAnchor(equalTo anchor: NSLayoutAnchor<NSLayoutXAxisAnchor>) {
-        view.centerXAnchor.constraint(equalTo: anchor).isActive = true
-    }
-
-    func centerYAnchor(equalTo anchor: NSLayoutAnchor<NSLayoutYAxisAnchor>) {
-        view.centerYAnchor.constraint(equalTo: anchor).isActive = true
-    }
+    // MARK: Methods
 
     func equalToSuperView() {
-        guard let superview = view.superview else { return }
-        verticalAnchor(equalTo: superview)
-        horizontalAnchor(equalTo: superview)
+        guard let superView = view.superview else { return }
+
+        NSLayoutConstraint.activate([
+            topAnchor?.constraint(equalTo: superView.topAnchor),
+            leadingAnchor?.constraint(equalTo: superView.leadingAnchor),
+            trailingAnchor?.constraint(equalTo: superView.trailingAnchor),
+            bottomAnchor?.constraint(equalTo: superView.bottomAnchor)
+        ].compactMap { $0 })
     }
 }

--- a/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
+++ b/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper+UIView.swift
@@ -1,0 +1,73 @@
+//
+//  LayoverConstraintWrapper+UIView.swift
+//  Layover
+//
+//  Created by 김인환 on 11/20/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+extension LayoverConstraintWrapper where Base: UIView {
+
+    func makeConstraints(_ closure: (ConstraintMaker) -> Void) {
+        base.translatesAutoresizingMaskIntoConstraints = false
+        closure(ConstraintMaker(base))
+    }
+}
+
+final class ConstraintMaker {
+    let view: UIView
+
+    init(_ view: UIView) {
+        self.view = view
+    }
+
+    func topAnchor(equalTo anchor: NSLayoutYAxisAnchor, constant: CGFloat = 0) {
+        view.topAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+    }
+
+    func bottomAnchor(equalTo anchor: NSLayoutYAxisAnchor, constant: CGFloat = 0) {
+        view.bottomAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+    }
+
+    func leadingAnchor(equalTo anchor: NSLayoutXAxisAnchor, constant: CGFloat = 0) {
+        view.leadingAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+    }
+
+    func trailingAnchor(equalTo anchor: NSLayoutXAxisAnchor, constant: CGFloat = 0) {
+        view.trailingAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+    }
+
+    func widthAnchor(equalToConstant constant: CGFloat) {
+        view.widthAnchor.constraint(equalToConstant: constant).isActive = true
+    }
+
+    func widthAnchor(equalTo anchor: NSLayoutDimension, multiplier: CGFloat = 1.0) {
+        view.widthAnchor.constraint(equalTo: anchor, multiplier: multiplier).isActive = true
+    }
+
+    func heightAnchor(equalToConstant constant: CGFloat) {
+        view.heightAnchor.constraint(equalToConstant: constant).isActive = true
+    }
+
+    func heightAnchor(equalTo anchor: NSLayoutDimension, multiplier: CGFloat = 1.0) {
+        view.heightAnchor.constraint(equalTo: anchor, multiplier: multiplier).isActive = true
+    }
+
+    func verticalAnchor(equalTo relativeView: UIView) {
+        topAnchor(equalTo: relativeView.topAnchor)
+        bottomAnchor(equalTo: relativeView.bottomAnchor)
+    }
+
+    func horizontalAnchor(equalTo relativeView: UIView) {
+        leadingAnchor(equalTo: relativeView.leadingAnchor)
+        trailingAnchor(equalTo: relativeView.trailingAnchor)
+    }
+
+    func equalToSuperView() {
+        guard let superview = view.superview else { return }
+        verticalAnchor(equalTo: superview)
+        horizontalAnchor(equalTo: superview)
+    }
+}

--- a/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper.swift
+++ b/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper.swift
@@ -10,9 +10,6 @@ import UIKit
 
 struct LayoverConstraintWrapper<Base> {
     let base: Base
-    init(base: Base) {
-        self.base = base
-    }
 }
 
 protocol LayoverConstraintCompatible {
@@ -25,7 +22,7 @@ extension LayoverConstraintCompatible {
     var lor: LayoverConstraintWrapper<Self> {
         get {
             return LayoverConstraintWrapper(base: self)
-        } set { }
+        }
     }
 }
 

--- a/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper.swift
+++ b/iOS/Layover/Layover/Extensions/LayoverConstraint/LayoverConstraintWrapper.swift
@@ -1,0 +1,32 @@
+//
+//  LayoverConstraintWrapper.swift
+//  Layover
+//
+//  Created by 김인환 on 11/20/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+struct LayoverConstraintWrapper<Base> {
+    let base: Base
+    init(base: Base) {
+        self.base = base
+    }
+}
+
+protocol LayoverConstraintCompatible {
+    associatedtype LayoverConstraintBase
+
+    var lor: LayoverConstraintWrapper<LayoverConstraintBase> { get }
+}
+
+extension LayoverConstraintCompatible {
+    var lor: LayoverConstraintWrapper<Self> {
+        get {
+            return LayoverConstraintWrapper(base: self)
+        } set { }
+    }
+}
+
+extension UIView: LayoverConstraintCompatible { }

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -12,6 +12,8 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     // MARK: - Properties
 
+    private let loopingPlayerView = LoopingPlayerView()
+
     // MARK: - UI Components
 
     // MARK: - Object lifecycle
@@ -35,7 +37,12 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     }
 
     private func setConstraints() {
+        addSubviews(loopingPlayerView)
+        loopingPlayerView.backgroundColor = .green
 
+        loopingPlayerView.lor.makeConstraints {
+            $0.equalToSuperView()
+        }
     }
 
     // MARK: - Methods

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -41,7 +41,7 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
         loopingPlayerView.backgroundColor = .green
 
         loopingPlayerView.lor.makeConstraints {
-            $0.equalToSuperView()
+            $0.center.equalToSuperView()
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -40,6 +40,7 @@ final class HomeViewController: BaseViewController, HomeDisplayLogic {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? HomeCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.layer.cornerRadius = 10
+        cell.clipsToBounds = true
         return cell
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
오토레이아웃을 편리하게 작성할 수 있는 extension wrapper를 구현했습니다.
완전 Snapkit...처럼은 아니지만 어느정도 컨셉은 비슷하게 ^^;; 구현해보려고 노력했습니다.
전부 다 구현한 건 아니고 필요한 메서드는 ConstraintMaker에 구현해주시면 될 것 같아요. 
우선은 생각나는 메서드만 구현해봤습니다.

예시는 Home 셀에 적용해보았습니다. lor 네임스페이스로 접근하셔서 사용하심 될 듯 합니다.
근데 SnapKit 처럼 만드는 건 어떻게 해야 할까요? 얼핏 봤을때는 ConstraintItem 타입으로 인자가 들어오는 것 같았는데...

```swift
loopingPlayerView.lor.makeConstraints {
       $0.equalToSuperView()
}
```

많은 지적 부탁드립니다.

#### Linked Issue
close #49
