### PR TITLE
Feat: 지도 탭 캐러셀 반복재생 및 `LoopingPlayerView`, `createCarouselLayout` 변경 사항

### DIFF
--- a/iOS/Layover/Layover/Extensions/UICollectionViewLayout+.swift
+++ b/iOS/Layover/Layover/Extensions/UICollectionViewLayout+.swift
@@ -8,27 +8,14 @@
 
 import UIKit
 
-extension UICollectionViewLayout {
-    static func createCarouselLayout(groupWidthDimension: CGFloat,
-                                     groupHeightDimension: CGFloat,
-                                     maximumZoomScale: CGFloat,
-                                     minimumZoomScale: CGFloat) -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                              heightDimension: .fractionalHeight(1))
+extension NSCollectionLayoutSection {
+    static func makeCarouselSection(groupWidthDimension: CGFloat) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(groupWidthDimension),
-                                               heightDimension: .fractionalHeight(groupHeightDimension))
+                                               heightDimension: .fractionalHeight(1.0))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        let section = NSCollectionLayoutSection(group: group)
-        section.orthogonalScrollingBehavior = .groupPagingCentered
-        section.visibleItemsInvalidationHandler = { items, offset, environment in
-            let containerWidth = environment.container.contentSize.width
-            items.forEach { item in
-                let distanceFromCenter = abs((item.center.x - offset.x) - environment.container.contentSize.width / 2.0)
-                let scale = max(maximumZoomScale - (distanceFromCenter / containerWidth), minimumZoomScale)
-                item.transform = CGAffineTransform(scaleX: scale, y: scale)
-            }
-        }
-        return UICollectionViewCompositionalLayout(section: section)
+        return NSCollectionLayoutSection(group: group)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -111,7 +111,6 @@ final class HomeViewController: BaseViewController, HomeDisplayLogic {
                                                    heightDimension: .fractionalHeight(groupHeightDimension))
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                            subitems: [item])
-
             let section = NSCollectionLayoutSection(group: group)
             section.interGroupSpacing = 0
             section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)

--- a/iOS/Layover/Layover/Scenes/MapScene/MapCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapCarouselCollectionViewCell.swift
@@ -7,16 +7,57 @@
 //
 
 import UIKit
+import AVFoundation
 
 final class MapCarouselCollectionViewCell: UICollectionViewCell {
 
+    private let loopingPlayerView = LoopingPlayerView()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .white
+        setUI()
+        render()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        setUI()
+        render()
+    }
+
+    override func prepareForReuse() {
+        render()
+    }
+
+    func configure(urlString: String) {
+        loopingPlayerView.prepareVideo(with: URL(string: urlString)!,
+                                       timeRange: CMTimeRange(start: .zero, duration: CMTime(value: 1800, timescale: 600)))
+        loopingPlayerView.player?.isMuted = true
+    }
+
+    func didMoveToCenter() {
+        loopingPlayerView.play()
+    }
+
+    func didMoveToSide() {
+        loopingPlayerView.pause()
+    }
+
+    private func setUI() {
+        backgroundColor = .background
+        contentView.addSubview(loopingPlayerView)
+        loopingPlayerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+        loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+        loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+        loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    private func render() {
+        layer.cornerRadius = 10
+        clipsToBounds = true
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapCarouselCollectionViewCell.swift
@@ -11,7 +11,7 @@ import AVFoundation
 
 final class MapCarouselCollectionViewCell: UICollectionViewCell {
 
-    private let loopingPlayerView = LoopingPlayerView()
+    private(set) var loopingPlayerView = LoopingPlayerView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,22 +25,10 @@ final class MapCarouselCollectionViewCell: UICollectionViewCell {
         render()
     }
 
-    override func prepareForReuse() {
-        render()
-    }
-
-    func configure(urlString: String) {
-        loopingPlayerView.prepareVideo(with: URL(string: urlString)!,
+    func configure(url: URL) {
+        loopingPlayerView.prepareVideo(with: url,
                                        timeRange: CMTimeRange(start: .zero, duration: CMTime(value: 1800, timescale: 600)))
         loopingPlayerView.player?.isMuted = true
-    }
-
-    func didMoveToCenter() {
-        loopingPlayerView.play()
-    }
-
-    func didMoveToSide() {
-        loopingPlayerView.pause()
     }
 
     private func setUI() {
@@ -48,10 +36,10 @@ final class MapCarouselCollectionViewCell: UICollectionViewCell {
         contentView.addSubview(loopingPlayerView)
         loopingPlayerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-        loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
-        loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-        loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-        loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
 

--- a/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
@@ -41,13 +41,14 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
 
     func fetchVideos() {
         // TODO: worker 네트워크 호출
-        let dummyData: [String] = ["http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8",
+        let dummyURLs: [URL] = ["http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
                                    "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"]
-        presenter?.presentFetchedVideos(with: MapModels.FetchVideo.Reponse(videoURLs: dummyData))
+            .compactMap { URL(string: $0) }
+        presenter?.presentFetchedVideos(with: MapModels.FetchVideo.Reponse(videoURLs: dummyURLs))
     }
 
     private func checkCurrentLocationAuthorization(for status: CLAuthorizationStatus) {

--- a/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
@@ -11,6 +11,7 @@ import Foundation
 
 protocol MapBusinessLogic {
     func checkLocationAuthorizationStatus()
+    func fetchVideos()
 }
 
 protocol MapDataStore { }
@@ -23,6 +24,10 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
 
     private let locationManager = CLLocationManager()
 
+    private var latitude: Double?
+
+    private var longitude: Double?
+
     var presenter: MapPresentationLogic?
 
     override init() {
@@ -32,6 +37,17 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
 
     func checkLocationAuthorizationStatus() {
         checkCurrentLocationAuthorization(for: locationManager.authorizationStatus)
+    }
+
+    func fetchVideos() {
+        // TODO: worker 네트워크 호출
+        let dummyData: [String] = ["http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8",
+                                   "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+                                   "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8",
+                                   "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+                                   "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+                                   "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"]
+        presenter?.presentFetchedVideos(response: MapModels.FetchVideo.Reponse(videoURLs: dummyData))
     }
 
     private func checkCurrentLocationAuthorization(for status: CLAuthorizationStatus) {
@@ -52,4 +68,12 @@ extension MapInteractor: CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         checkCurrentLocationAuthorization(for: manager.authorizationStatus)
     }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        if let location = locations.first {
+            longitude = location.coordinate.longitude
+            latitude = location.coordinate.latitude
+        }
+    }
+
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapInteractor.swift
@@ -47,7 +47,7 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"]
-        presenter?.presentFetchedVideos(response: MapModels.FetchVideo.Reponse(videoURLs: dummyData))
+        presenter?.presentFetchedVideos(with: MapModels.FetchVideo.Reponse(videoURLs: dummyData))
     }
 
     private func checkCurrentLocationAuthorization(for status: CLAuthorizationStatus) {

--- a/iOS/Layover/Layover/Scenes/MapScene/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapModels.swift
@@ -18,7 +18,7 @@ enum MapModels {
         }
 
         struct Reponse {
-            var videoURLs: [String]
+            var videoURLs: [URL]
         }
 
         struct ViewModel {
@@ -26,7 +26,7 @@ enum MapModels {
 
             struct VideoDataSource: Hashable {
                 var id = UUID()
-                var videoURLs: String
+                var videoURL: URL
             }
         }
     }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapModels.swift
@@ -10,6 +10,24 @@ import Foundation
 
 enum MapModels {
 
-    // MARK: - Use Cases
+    // MARK: - Fetch Video Use Cases
+    enum FetchVideo {
+        struct Request {
+            var latitude: Double
+            var longitude: Double
+        }
 
+        struct Reponse {
+            var videoURLs: [String]
+        }
+
+        struct ViewModel {
+            var videoDataSources: [VideoDataSource]
+
+            struct VideoDataSource: Hashable {
+                var id = UUID()
+                var videoURLs: String
+            }
+        }
+    }
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol MapPresentationLogic {
     func presentCurrentLocation()
     func presentDefaultLocation()
-    func presentFetchedVideos(response: MapModels.FetchVideo.Reponse)
+    func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse)
 }
 
 final class MapPresenter: MapPresentationLogic {
@@ -29,7 +29,8 @@ final class MapPresenter: MapPresentationLogic {
         // TODO: 위치 관련 기능 사용 불가, 디폴트 위치로 이동
     }
 
-    func presentFetchedVideos(response: MapModels.FetchVideo.Reponse) {
-        viewController?.displayFetchedVideos(viewModel: MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURLs: $0) }))
+    func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse) {
+        let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURLs: $0) })
+        viewController?.displayFetchedVideos(viewModel: viewModel)
     }
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol MapPresentationLogic {
     func presentCurrentLocation()
     func presentDefaultLocation()
+    func presentFetchedVideos(response: MapModels.FetchVideo.Reponse)
 }
 
 final class MapPresenter: MapPresentationLogic {
@@ -26,5 +27,9 @@ final class MapPresenter: MapPresentationLogic {
 
     func presentDefaultLocation() {
         // TODO: 위치 관련 기능 사용 불가, 디폴트 위치로 이동
+    }
+
+    func presentFetchedVideos(response: MapModels.FetchVideo.Reponse) {
+        viewController?.displayFetchedVideos(viewModel: MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURLs: $0) }))
     }
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapPresenter.swift
@@ -30,7 +30,7 @@ final class MapPresenter: MapPresentationLogic {
     }
 
     func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse) {
-        let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURLs: $0) })
+        let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURL: $0) })
         viewController?.displayFetchedVideos(viewModel: viewModel)
     }
 }

--- a/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
@@ -53,7 +53,7 @@ final class MapViewController: BaseViewController {
     private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, ViewModel.VideoDataSource>(collectionView: carouselCollectionView) { collectionView, indexPath, item in
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MapCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? MapCarouselCollectionViewCell else { return UICollectionViewCell() }
-        cell.configure(urlString: item.videoURLs)
+        cell.configure(url: item.videoURL)
         return cell
     }
 
@@ -129,9 +129,9 @@ final class MapViewController: BaseViewController {
                 item.transform = CGAffineTransform(scaleX: scale, y: scale)
                 let cell = self.carouselCollectionView.cellForItem(at: item.indexPath) as? MapCarouselCollectionViewCell
                 if scale >= maximumZoomScale * 0.9 {
-                    cell?.didMoveToCenter()
+                    cell?.loopingPlayerView.play()
                 } else {
-                    cell?.didMoveToSide()
+                    cell?.loopingPlayerView.pause()
                 }
             }
         }
@@ -144,7 +144,7 @@ extension MapViewController: MapDisplayLogic {
 
     func displayFetchedVideos(viewModel: ViewModel) {
         carouselCollectionView.dataSource = carouselDatasource
-        var snapshot = NSDiffableDataSourceSnapshot<UUID, ViewModel.VideoDataSource>()
+        var snapshot: NSDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<UUID, ViewModel.VideoDataSource>()
         snapshot.appendSections([UUID()])
         snapshot.appendItems(viewModel.videoDataSources)
         carouselDatasource.apply(snapshot)

--- a/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
@@ -44,11 +44,7 @@ final class MapViewController: BaseViewController {
     private let uploadButton: LOCircleButton = LOCircleButton(style: .add, diameter: 52)
 
     private lazy var carouselCollectionView: UICollectionView = {
-        let layout: UICollectionViewLayout = .createCarouselLayout(groupWidthDimension: 94/375,
-                                                                   groupHeightDimension: 1.0,
-                                                                   maximumZoomScale: 1.0,
-                                                                   minimumZoomScale: 73/94)
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
         collectionView.backgroundColor = .clear
         collectionView.register(MapCarouselCollectionViewCell.self, forCellWithReuseIdentifier: MapCarouselCollectionViewCell.identifier)
         return collectionView
@@ -57,7 +53,7 @@ final class MapViewController: BaseViewController {
     private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, Int>(collectionView: carouselCollectionView) { collectionView, indexPath, _ in
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MapCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? MapCarouselCollectionViewCell else { return UICollectionViewCell() }
-        cell.layer.cornerRadius = 10
+        cell.configure(urlString: item.videoURLs)
         return cell
     }
 
@@ -105,17 +101,42 @@ final class MapViewController: BaseViewController {
         ])
     }
 
-    private func setCarouselCollectionView() {
-        carouselCollectionView.dataSource = carouselDatasource
-        var snapshot = NSDiffableDataSourceSnapshot<UUID, Int>()
-        snapshot.appendSections([UUID()])
-        snapshot.appendItems([1, 2, 3, 4, 5, 6, 7, 8, 9])
-        carouselDatasource.apply(snapshot)
+    private func createLayout() -> UICollectionViewLayout {
+        let groupWidthDimension: CGFloat = 94/375
+        let minumumZoomScale: CGFloat = 73/94
+        let maximumZoomScale: CGFloat = 1.0
+        let section: NSCollectionLayoutSection = .makeCarouselSection(groupWidthDimension: groupWidthDimension)
+        section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.interGroupSpacing = 0
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 200, bottom: 0, trailing: 200)
+        section.visibleItemsInvalidationHandler = { (items, offset, environment) in
+            let containerWidth = environment.container.contentSize.width
+            items.forEach { item in
+                let distanceFromCenter = abs((item.center.x - offset.x) - environment.container.contentSize.width / 2.0)
+                let scale = max(maximumZoomScale - (distanceFromCenter / containerWidth), minumumZoomScale)
+                item.transform = CGAffineTransform(scaleX: scale, y: scale)
+                let cell = self.carouselCollectionView.cellForItem(at: item.indexPath) as? MapCarouselCollectionViewCell
+                if scale >= maximumZoomScale * 0.9 {
+                    cell?.didMoveToCenter()
+                } else {
+                    cell?.didMoveToSide()
+                }
+            }
+        }
+        return UICollectionViewCompositionalLayout(section: section)
     }
 
 }
 
 extension MapViewController: MapDisplayLogic {
+
+    func displayFetchedVideos(viewModel: ViewModel) {
+        carouselCollectionView.dataSource = carouselDatasource
+        var snapshot = NSDiffableDataSourceSnapshot<UUID, ViewModel.VideoDataSource>()
+        snapshot.appendSections([UUID()])
+        snapshot.appendItems(viewModel.videoDataSources)
+        carouselDatasource.apply(snapshot)
+    }
 
 }
 

--- a/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/MapScene/MapViewController.swift
@@ -10,7 +10,7 @@ import MapKit
 import UIKit
 
 protocol MapDisplayLogic: AnyObject {
-
+    func displayFetchedVideos(viewModel: MapModels.FetchVideo.ViewModel)
 }
 
 final class MapViewController: BaseViewController {
@@ -50,7 +50,7 @@ final class MapViewController: BaseViewController {
         return collectionView
     }()
 
-    private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, Int>(collectionView: carouselCollectionView) { collectionView, indexPath, _ in
+    private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, ViewModel.VideoDataSource>(collectionView: carouselCollectionView) { collectionView, indexPath, item in
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MapCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? MapCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.configure(urlString: item.videoURLs)
@@ -59,22 +59,34 @@ final class MapViewController: BaseViewController {
 
     // MARK: - Properties
 
+    typealias Models = MapModels
+    typealias ViewModel = Models.FetchVideo.ViewModel
+
     var interactor: MapBusinessLogic?
 
     // MARK: - Life Cycle
 
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        MapConfigurator.shared.configure(self)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        MapConfigurator.shared.configure(self)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        MapConfigurator.shared.configure(self)
         interactor?.checkLocationAuthorizationStatus()
-        setCarouselCollectionView()
+        interactor?.fetchVideos()
     }
 
     // MARK: - UI + Layout
 
     override func setConstraints() {
+        view.addSubviews(mapView, searchButton, currentLocationButton, uploadButton, carouselCollectionView)
         [mapView, searchButton, currentLocationButton, uploadButton, carouselCollectionView].forEach {
-            view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
 

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -24,11 +24,16 @@ final class LoopingPlayerView: UIView {
 
     private var playerLayer: AVPlayerLayer? { layer as? AVPlayerLayer }
 
+    var isPlaying: Bool {
+        get { player?.timeControlStatus == .playing }
+    }
+
     // MARK: - View Life Cycle
 
     override func layoutSubviews() {
         super.layoutSubviews()
         playerLayer?.frame = bounds
+        playerLayer?.videoGravity = .resizeAspectFill
     }
 
     // MARK: - Methods
@@ -41,17 +46,21 @@ final class LoopingPlayerView: UIView {
     }
 
     func disable() {
-        player?.pause()
+        pause()
         player = nil
         looper = nil
     }
 
     func play() {
-        player?.play()
+        if !isPlaying {
+            player?.play()
+        }
     }
 
     func pause() {
-        player?.pause()
+        if isPlaying {
+            player?.pause()
+        }
     }
 }
 

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -25,7 +25,7 @@ final class LoopingPlayerView: UIView {
     private var playerLayer: AVPlayerLayer? { layer as? AVPlayerLayer }
 
     var isPlaying: Bool {
-        get { player?.timeControlStatus == .playing }
+        player?.timeControlStatus == .playing
     }
 
     // MARK: - View Life Cycle
@@ -66,7 +66,7 @@ final class LoopingPlayerView: UIView {
 
 #Preview {
     let view = LoopingPlayerView()
-    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!, 
+    view.prepareVideo(with: URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!,
                       timeRange: .init(start: .zero,
                                        end: .init(seconds: 3.0, preferredTimescale: CMTimeScale(1.0))))
     view.play()


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.
- 지도 탭 캐러셀에 LoopingPlayerView를 연동하여 3초 반복재생을 구현했습니다.
지금은 맥시멈 크기의 90%가 되는 순간 셀을 재생하게 됩니다.

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

### LoopingPlayerView에 isPlaying 프로퍼티 추가했습니다
공통으로 사용하는 부분이라 미리 말씀드렸어야하는데... 시간이 너무 늦어 우선 추가해보았습니다..
불필요하다거나 더 좋은 방법이 있다 싶으시면 말씀해주세용

player의 timeControlStatus 여부로 판단하도록 했습니다.
그리고 isPlaying 여부를 판단해서 play, pause하도록 수정했습니다..

```swift
    var isPlaying: Bool {
        get { player?.timeControlStatus == .playing }
    }
```

### createCarouselLayout를 makeCarouselSection으로..
- compositionalLayout의 수평스크롤 사용시 scrollDelegate가 트리거되지 않는다는 사실을 알게되었습니다..
- scrollDelegate를 통해 센터에 위치한 셀의 영상을 재생해주려고 했는데, 이게 현재로서는 불가능해보여서
visibleItemsInvalidationHandler를 다시 사용해야했습니다.
- 원래 만들어둔 익스텐션에 이스케이핑 클로저를 전달하는 방식도 생각해보았으나, 그것보다 그냥 동일한 섹션을 만들어주고 visibleItemsInvalidationHandler는 뷰컨에서 처리하는게 낫지않나 싶었습니다..ㅠ
- 최적의 방법은 아닌 것 같은데, 너무 오래 고민하다보니 차라리 다른 피쳐를 진행 후 다시 생각해보는게 생산적일 것 같다고 생각했습니다..!! 방법은 계속 고민해보겠습니다..


##### 📸 ScreenShot
작동, 구현화면

![Simulator Screen Recording - iPhone 15 - 2023-11-21 at 15 19 33](https://github.com/boostcampwm2023/iOS09-Layover/assets/70168249/7e4c2359-f460-44ac-9e2f-d152ba1d126f)


#### Linked Issue
close #46 
