### PR TITLE
feat: 홈 탭 캐러셀에 PlayerView 연동

### DIFF
--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -57,6 +57,7 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     func setVideo(url: URL) {
         loopingPlayerView.prepareVideo(with: url, timeRange: CMTimeRange(start: .zero, end: CMTime(value: 1800, timescale: 600)))
+        loopingPlayerView.player?.isMuted = true
     }
 
     func playVideo() {

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import CoreMedia
 
 final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
@@ -55,14 +54,10 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
         ])
     }
 
-    override func prepareForReuse() {
-        loopingPlayerView.disable()
-    }
-
     // MARK: - Methods
 
-    func setVideo(url: URL) {
-        loopingPlayerView.prepareVideo(with: url, timeRange: CMTimeRange(start: .zero, end: CMTime(value: 1800, timescale: 600)))
+    func setVideo(url: URL, loopingAt time: TimeInterval) {
+        loopingPlayerView.prepareVideo(with: url, loopStart: time, duration: 3.0)
         loopingPlayerView.player?.isMuted = true
     }
 

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -25,20 +25,22 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setup()
+        setUI()
         setConstraints()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setup()
+        setUI()
         setConstraints()
     }
 
     // MARK: - Setup
 
-    private func setup() {
-        backgroundColor = .white
+    private func setUI() {
+        backgroundColor = .darkGrey
+        layer.cornerRadius = 10
+        clipsToBounds = true
     }
 
     private func setConstraints() {
@@ -51,6 +53,10 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
             loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
+    }
+
+    override func prepareForReuse() {
+        loopingPlayerView.disable()
     }
 
     // MARK: - Methods

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -7,12 +7,19 @@
 //
 
 import UIKit
+import CoreMedia
 
 final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
+    // MARK: - UI Components
+
+    private let loopingPlayerView = LoopingPlayerView()
+
     // MARK: - Properties
 
-    // MARK: - UI Components
+    var isPlayingVideos: Bool {
+        loopingPlayerView.isPlaying
+    }
 
     // MARK: - Object lifecycle
 
@@ -35,8 +42,28 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     }
 
     private func setConstraints() {
+        contentView.addSubviews(loopingPlayerView)
+        [loopingPlayerView].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
 
+        NSLayoutConstraint.activate([
+            loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
     }
 
     // MARK: - Methods
+
+    func setVideo(url: URL) {
+        loopingPlayerView.prepareVideo(with: url, timeRange: CMTimeRange(start: .zero, end: CMTime(value: 1800, timescale: 600)))
+    }
+
+    func playVideo() {
+        loopingPlayerView.play()
+    }
+
+    func pauseVideo() {
+        loopingPlayerView.pause()
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
@@ -23,7 +23,6 @@ final class HomeConfigurator: Configurator {
 
         let interactor = HomeInteractor()
         interactor.presenter = presenter
-        interactor.worker = HomeWorker()
 
         viewController.router = router
         viewController.interactor = interactor

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -9,77 +9,28 @@
 import UIKit
 
 protocol HomeBusinessLogic {
-    func fetchFromLocalDataStore(with request: HomeModels.FetchFromLocalDataStore.Request)
-    func fetchFromRemoteDataStore(with request: HomeModels.FetchFromRemoteDataStore.Request)
-    func trackAnalytics(with request: HomeModels.TrackAnalytics.Request)
-    func performHome(with request: HomeModels.PerformHome.Request)
+    func fetchVideos(with: HomeModels.CarouselVideos.Request)
 }
 
 protocol HomeDataStore {
-    var exampleVariable: String? { get set }
+
 }
 
-class HomeInteractor: HomeBusinessLogic, HomeDataStore {
+final class HomeInteractor: HomeBusinessLogic, HomeDataStore {
 
     // MARK: - Properties
 
     typealias Models = HomeModels
 
-    lazy var worker = HomeWorker()
     var presenter: HomePresentationLogic?
 
-    var exampleVariable: String?
+    // MARK: - Use Case
 
-    // MARK: - Use Case - Fetch From Local DataStore
-
-    func fetchFromLocalDataStore(with request: HomeModels.FetchFromLocalDataStore.Request) {
-        let response = Models.FetchFromLocalDataStore.Response()
-        presenter?.presentFetchFromLocalDataStore(with: response)
-    }
-
-    // MARK: - Use Case - Fetch From Remote DataStore
-
-    func fetchFromRemoteDataStore(with request: HomeModels.FetchFromRemoteDataStore.Request) {
-        // fetch something from backend and return the values here
-        // <#Network Worker Instance#>.fetchFromRemoteDataStore(completion: { [weak self] code in
-        //     let response = Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
-        //     self?.presenter?.presentFetchFromRemoteDataStore(with: response)
-        // })
-    }
-
-    // MARK: - Use Case - Track Analytics
-
-    func trackAnalytics(with request: HomeModels.TrackAnalytics.Request) {
-        // call analytics library/wrapper here to track analytics
-        // <#Analytics Worker Instance#>.trackAnalytics(event: request.event)
-
-        let response = Models.TrackAnalytics.Response()
-    }
-
-    // MARK: - Use Case - Home
-
-    func performHome(with request: HomeModels.PerformHome.Request) {
-        let error = worker.validate(exampleVariable: request.exampleVariable)
-
-        if let error = error {
-            let response = Models.PerformHome.Response(error: error)
-            presenter?.presentPerformHome(with: response)
-            return
-        }
-
-        // <#Network Worker Instance#>.performHome(completion: { [weak self, weak request] isSuccessful, error in
-        //     self?.completion(request?.exampleVariable, isSuccessful, error)
-        // })
-    }
-
-    private func completion(_ exampleVariable: String?, _ isSuccessful: Bool, _ error: Models.HomeError?) {
-        if isSuccessful {
-            // do something on success
-            let goodExample = exampleVariable ?? ""
-            self.exampleVariable = goodExample
-        }
-
-        let response = Models.PerformHome.Response(error: error)
-        presenter?.presentPerformHome(with: response)
+    func fetchVideos(with request: Models.CarouselVideos.Request) {
+        let response = Models.CarouselVideos.Response(videoURLs: [
+            URL(string: "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8")!,
+            URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!
+        ])
+        presenter?.presentVideoURL(with: response)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -16,16 +16,18 @@ protocol HomeDataStore {
 
 }
 
-final class HomeInteractor: HomeBusinessLogic, HomeDataStore {
+final class HomeInteractor: HomeDataStore {
 
     // MARK: - Properties
 
     typealias Models = HomeModels
 
     var presenter: HomePresentationLogic?
+}
 
-    // MARK: - Use Case
+// MARK: - Use Case
 
+extension HomeInteractor: HomeBusinessLogic {
     func fetchVideos(with request: Models.CarouselVideos.Request) {
         let response = Models.CarouselVideos.Response(videoURLs: [
             URL(string: "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8")!,

--- a/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
@@ -12,77 +12,16 @@ enum HomeModels {
 
     // MARK: - Use Cases
 
-    enum FetchFromLocalDataStore {
+    enum CarouselVideos {
         struct Request {
         }
 
         struct Response {
+            var videoURLs: [URL]
         }
 
         struct ViewModel {
-            var exampleTranslation: String?
-        }
-    }
-
-    enum FetchFromRemoteDataStore {
-        struct Request {
-        }
-
-        struct Response {
-            var exampleVariable: String?
-        }
-
-        struct ViewModel {
-            var exampleVariable: String?
-        }
-    }
-
-    enum TrackAnalytics {
-        struct Request {
-            var event: AnalyticsEvents
-        }
-
-        struct Response {
-        }
-
-        struct ViewModel {
-        }
-    }
-
-    enum PerformHome {
-        struct Request {
-            var exampleVariable: String?
-        }
-
-        struct Response {
-            var error: HomeError?
-        }
-
-        struct ViewModel {
-            var error: HomeError?
-        }
-    }
-
-    // MARK: - Types
-
-    // replace with `AnalyticsEvents` with `AnalyticsConstants` if needed
-    typealias AnalyticsEvents = ExampleAnalyticsEvents
-    typealias HomeError = Error<HomeErrorType>
-
-    enum ExampleAnalyticsEvents {
-        case screenView
-    }
-
-    enum HomeErrorType {
-        case emptyExampleVariable, networkError
-    }
-
-    struct Error<T> {
-        var type: T
-        var message: String?
-
-        init(type: T) {
-            self.type = type
+            var videoURLs: [URL]
         }
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
@@ -9,53 +9,20 @@
 import UIKit
 
 protocol HomePresentationLogic {
-    func presentFetchFromLocalDataStore(with response: HomeModels.FetchFromLocalDataStore.Response)
-    func presentFetchFromRemoteDataStore(with response: HomeModels.FetchFromRemoteDataStore.Response)
-//    func presentTrackAnalytics(with response: HomeModels.TrackAnalytics.Response)
-    func presentPerformHome(with response: HomeModels.PerformHome.Response)
+    func presentVideoURL(with response: HomeModels.CarouselVideos.Response)
 }
 
-class HomePresenter: HomePresentationLogic {
+final class HomePresenter: HomePresentationLogic {
 
     // MARK: - Properties
 
     typealias Models = HomeModels
     weak var viewController: HomeDisplayLogic?
 
-    // MARK: - Use Case - Fetch From Local DataStore
-
-    func presentFetchFromLocalDataStore(with response: HomeModels.FetchFromLocalDataStore.Response) {
-        let translation = "Some localized text."
-        let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
-//        viewController?.displayFetchFromLocalDataStore(with: viewModel)
-    }
-
-    // MARK: - Use Case - Fetch From Remote DataStore
-
-    func presentFetchFromRemoteDataStore(with response: HomeModels.FetchFromRemoteDataStore.Response) {
-        let formattedExampleVariable = response.exampleVariable ?? ""
-        let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: formattedExampleVariable)
-//        viewController?.displayFetchFromRemoteDataStore(with: viewModel)
-    }
-
-    // MARK: - Use Case - Track Analytics
-
     // MARK: - Use Case - Home
 
-    func presentPerformHome(with response: HomeModels.PerformHome.Response) {
-        var responseError = response.error
-
-        if let error = responseError {
-            switch error.type {
-            case .emptyExampleVariable:
-                responseError?.message = "Localized empty/nil error message."
-
-            case .networkError:
-                responseError?.message = "Localized network error message."
-            }
-        }
-
-        let viewModel = Models.PerformHome.ViewModel(error: responseError)
-//        viewController?.displayPerformHome(with: viewModel)
+    func presentVideoURL(with response: HomeModels.CarouselVideos.Response) {
+        let viewModel = HomeModels.CarouselVideos.ViewModel(videoURLs: response.videoURLs)
+        viewController?.displayVideoURLs(with: viewModel)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -39,7 +39,7 @@ final class HomeViewController: BaseViewController {
     private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, URL>(collectionView: carouselCollectionView) { collectionView, indexPath, url in
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? HomeCarouselCollectionViewCell else { return UICollectionViewCell() }
-        cell.setVideo(url: url)
+        cell.setVideo(url: url, loopingAt: .zero)
         cell.playVideo()
         return cell
     }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -122,6 +122,12 @@ final class HomeViewController: BaseViewController {
                     let distanceFromCenter = abs(itemCenterRelativeToOffset - containerWidth / 2.0) // container 중심점과 아이템 중심점의 거리
                     let scale = max(maximumZoomScale - (distanceFromCenter / containerWidth), minimumZoomScale) // 최대 비율에서 거리에 따라 비율을 줄임, 최소 비율보다 작아지지 않도록 함
                     item.transform = CGAffineTransform(scaleX: scale, y: scale)
+                    guard let cell = self.carouselCollectionView.cellForItem(at: item.indexPath) as? HomeCarouselCollectionViewCell else { return }
+                    if scale > 0.9 {
+                        cell.playVideo()
+                    } else {
+                        cell.pauseVideo()
+                    }
                 }
             }
             return section

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -41,7 +41,6 @@ final class HomeViewController: BaseViewController {
                                                             for: indexPath) as? HomeCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.setVideo(url: url)
         cell.playVideo()
-        cell.layer.cornerRadius = 10
         return cell
     }
 
@@ -123,9 +122,9 @@ final class HomeViewController: BaseViewController {
                     let scale = max(maximumZoomScale - (distanceFromCenter / containerWidth), minimumZoomScale) // 최대 비율에서 거리에 따라 비율을 줄임, 최소 비율보다 작아지지 않도록 함
                     item.transform = CGAffineTransform(scaleX: scale, y: scale)
                     guard let cell = self.carouselCollectionView.cellForItem(at: item.indexPath) as? HomeCarouselCollectionViewCell else { return }
-                    if scale > 0.9 {
+                    if scale >= 0.9 && !cell.isPlayingVideos {
                         cell.playVideo()
-                    } else {
+                    } else if scale < 0.9 && cell.isPlayingVideos {
                         cell.pauseVideo()
                     }
                 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -58,7 +58,7 @@ final class HomeViewController: BaseViewController, HomeDisplayLogic {
     // MARK: - Setup
 
     private func setup() {
-
+        HomeConfigurator.shared.configure(self)
     }
 
     // MARK: - View Lifecycle

--- a/iOS/Layover/Layover/Scenes/Home/HomeWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeWorker.swift
@@ -15,18 +15,4 @@ class HomeWorker {
     typealias Models = HomeModels
 
     // MARK: - Methods
-
-    // MARK: Screen Specific Validation
-
-    func validate(exampleVariable: String?) -> Models.HomeError? {
-        var error: Models.HomeError?
-
-        if exampleVariable?.isEmpty == false {
-            error = nil
-        } else {
-            error = Models.HomeError(type: .emptyExampleVariable)
-        }
-
-        return error
-    }
 }

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -37,11 +37,22 @@ final class LoopingPlayerView: UIView {
     }
 
     // MARK: - Methods
-
+    // TODO: - 아래쪽 메서드가 사용하기 괜찮으면 이 메서드 삭제
     func prepareVideo(with url: URL, timeRange: CMTimeRange) {
         let playerItem = AVPlayerItem(url: url)
         let player = AVQueuePlayer(playerItem: playerItem)
         looper = AVPlayerLooper(player: player, templateItem: playerItem, timeRange: timeRange)
+        self.player = player
+    }
+
+    func prepareVideo(with url: URL, loopStart: TimeInterval, duration: TimeInterval) {
+        let playerItem = AVPlayerItem(url: url)
+        let player = AVQueuePlayer(playerItem: playerItem)
+        looper = AVPlayerLooper(player: player,
+                                templateItem: playerItem,
+                                timeRange: CMTimeRange(start: CMTime(value: Int64(loopStart * 600),
+                                                                     timescale: CMTimeScale(600)),
+                                                       end: CMTime(value: Int64((loopStart + duration) * 600), timescale: 600)))
         self.player = player
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.
- 홈 뷰 캐러셀 뷰에 데모 영상 재생을 구현했습니다.
- 처음부터 3초까지 반복재생됩니다.
- compositional layout의 visibleItemsInvalidationHandler 에서 0.9 이상의 scale 크기가 되었을 때 재생, 그 이하는 일시정지 하도록 했습니다.
  - 해당 부분은 유경님께서 구현하신 방법 살펴보고 추후 수정할게요
 - 영상 URL 넣는 부분은 우선 VIP 사이클을 거쳐서 넣어주도록 했는데, 추후 API 나오면 DTO 맞게 수정해야겠습니다. Worker로도 네트워킹 처리하구요. 

##### 📸 ScreenShot
<img src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/704599ec-bc5b-4593-93ee-4efd46c8342a" width=40%>

#### Linked Issue
close #44
