### PR TITLE
chore: 컨트롤러 스웨거 설정

### DIFF
--- a/BE/layover/src/board/board.controller.ts
+++ b/BE/layover/src/board/board.controller.ts
@@ -1,29 +1,77 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, HttpStatus, Post } from '@nestjs/common';
 import { BoardService } from './board.service';
-import {ECustomCode} from "../response/ecustom-code.jenum.";
-import {CustomResponse} from "../response/custom-response";
+import { ECustomCode } from '../response/ecustom-code.jenum.';
+import { CustomResponse } from '../response/custom-response';
+import { PresignedUrlDto } from './dtos/presigned-url.dto';
+import { CreateBoardDto } from './dtos/create-board.dto';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { PresignedUrlResDto } from './dtos/presigned-url-res.dto';
+
+@ApiTags('게시물(영상 포함) API')
 @Controller('board')
 export class BoardController {
   constructor(private readonly boardService: BoardService) {}
-
+  @ApiOperation({
+    summary: 'presigned url 요청',
+    description:
+      'object storage에 영상을 업로드 하기 위한 presigned url을 요청합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'presigned url 요청 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(PresignedUrlResDto) },
+      },
+    },
+  })
   @Post('presigned-url')
-  async getPresignedUrl(
-    @Body('filename') filename: string,
-    @Body('filetype') filetype: string,
-  ) {
+  async getPresignedUrl(@Body() presignedUrlDto: PresignedUrlDto) {
+    const [filename, filetype] = [
+      presignedUrlDto.filename,
+      presignedUrlDto.filetype,
+    ];
+
     const { preSignedUrl } = this.boardService.makePreSignedUrl(
       filename,
       filetype,
     );
+
     throw new CustomResponse(ECustomCode.SUCCESS, { preSignedUrl });
   }
 
+  @ApiOperation({
+    summary: '게시글 업로드 요청',
+    description: '게시글에 들어갈 내용들과 함께 업로드를 요청합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '게시글 업로드 요청 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+      },
+    },
+  })
   @Post()
-  async createBoard(
-    @Body('title') title: string,
-    @Body('content') content: string,
-    @Body('location') location: string,
-  ) {
+  async createBoard(@Body() createBoardDto: CreateBoardDto) {
+    const [title, content, location] = [
+      createBoardDto.title,
+      createBoardDto.content,
+      createBoardDto.location,
+    ];
     await this.boardService.createBoard(title, content, location);
     throw new CustomResponse(ECustomCode.SUCCESS);
   }

--- a/BE/layover/src/board/dtos/create-board.dto.ts
+++ b/BE/layover/src/board/dtos/create-board.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateBoardDto {
+  @ApiProperty({
+    example: '부산 광안리',
+    description: '제목',
+  })
+  readonly title: string;
+
+  @ApiProperty({
+    example: 'chilling at the beach~',
+    description: '내용',
+  })
+  readonly content: string;
+
+  @ApiProperty({
+    example: '37.0213513391321',
+    description: '위치',
+  })
+  readonly location: string;
+}

--- a/BE/layover/src/board/dtos/presigned-url-res.dto.ts
+++ b/BE/layover/src/board/dtos/presigned-url-res.dto.ts
@@ -2,7 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class PresignedUrlResDto {
   @ApiProperty({
-    example: 'someUrl',
+    example:
+      'https://layover-original-video.s3.amazonaws.com/14bb1a79093f5b9443e9b8105.....',
     description: '동영상을 업로드 하기 위해 요청할 링크',
   })
   readonly presignedUrl: string;

--- a/BE/layover/src/board/dtos/presigned-url-res.dto.ts
+++ b/BE/layover/src/board/dtos/presigned-url-res.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PresignedUrlResDto {
+  @ApiProperty({
+    example: 'someUrl',
+    description: '동영상을 업로드 하기 위해 요청할 링크',
+  })
+  readonly presignedUrl: string;
+
+  constructor(presignedUrl: string) {
+    this.presignedUrl = presignedUrl;
+  }
+}

--- a/BE/layover/src/board/dtos/presigned-url.dto.ts
+++ b/BE/layover/src/board/dtos/presigned-url.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PresignedUrlDto {
+  @ApiProperty({
+    example: 'myVideo',
+    description: '업로드할 동영상 이름',
+  })
+  readonly filename: string;
+
+  @ApiProperty({
+    example: 'mp4',
+    description: '업로드할 동영상 타입',
+  })
+  readonly filetype: string;
+}

--- a/BE/layover/src/main.ts
+++ b/BE/layover/src/main.ts
@@ -4,6 +4,8 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { GlobalExceptionFilter } from './response/custom-response';
 
 import { readFileSync } from 'fs';
+import { TokenResDto } from './oauth/dtos/token-res.dto';
+import { PresignedUrlResDto } from './board/dtos/presigned-url-res.dto';
 const httpsOptions = {
   key: readFileSync('./private.key'),
   cert: readFileSync('./certificate.crt'),
@@ -19,7 +21,9 @@ async function bootstrap() {
     .setVersion('0.0.0.0.1')
     .addTag('Layover')
     .build();
-  const document = SwaggerModule.createDocument(app, config);
+  const document = SwaggerModule.createDocument(app, config, {
+    extraModels: [TokenResDto, PresignedUrlResDto],
+  });
   SwaggerModule.setup('api', app, document);
 
   await app.listen(3000);

--- a/BE/layover/src/oauth/dtos/apple-login.dto.ts
+++ b/BE/layover/src/oauth/dtos/apple-login.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AppleLoginDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: '애플 아이덴티티 토큰',
+  })
+  readonly identityToken: string;
+}

--- a/BE/layover/src/oauth/dtos/apple-signup.dto.ts
+++ b/BE/layover/src/oauth/dtos/apple-signup.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AppleSignupDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: '애플 아이덴티티 토큰',
+  })
+  readonly identityToken: string;
+
+  @ApiProperty({
+    example: 'myUsername',
+    description: '설정할 유저 닉네임',
+  })
+  readonly username: string;
+}

--- a/BE/layover/src/oauth/dtos/kakao-login.dto.ts
+++ b/BE/layover/src/oauth/dtos/kakao-login.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class KakaoLoginDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: '카카오 액세스 토큰',
+  })
+  readonly accessToken: string;
+}

--- a/BE/layover/src/oauth/dtos/kakao-signup.dto.ts
+++ b/BE/layover/src/oauth/dtos/kakao-signup.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class KakaoSignupDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: '카카오 액세스 토큰',
+  })
+  readonly accessToken: string;
+
+  @ApiProperty({
+    example: 'myUsername',
+    description: '설정할 유저 닉네임',
+  })
+  readonly username: string;
+}

--- a/BE/layover/src/oauth/dtos/token-res.dto.ts
+++ b/BE/layover/src/oauth/dtos/token-res.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TokenResDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: 'JWT Access 토큰',
+  })
+  accessToken: string;
+
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    description: 'JWT Refresh 토큰',
+  })
+  refreshToken: string;
+
+  constructor(accessToken: string, refreshToken: string) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -1,33 +1,118 @@
-import { Post, Body } from '@nestjs/common';
+import { Post, Body, HttpStatus } from '@nestjs/common';
 import { Controller } from '@nestjs/common';
 import { OauthService } from './oauth.service';
 import { JwtValidationPipe } from 'src/pipes/jwt.validation.pipe';
 import { CustomResponse } from '../response/custom-response';
 import { ECustomCode } from '../response/ecustom-code.jenum.';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { KakaoLoginDto } from './dtos/kakao-login.dto';
+import { AppleLoginDto } from './dtos/apple-login.dto';
+import { KakaoSignupDto } from './dtos/kakao-signup.dto';
+import { AppleSignupDto } from './dtos/apple-signup.dto';
+import { TokenResDto } from './dtos/token-res.dto';
 
+@ApiTags('OAuth API')
 @Controller('oauth')
+@ApiResponse({
+  status: HttpStatus.UNAUTHORIZED,
+  description: '잘못된 요청',
+  schema: {
+    type: 'object',
+    properties: {
+      customCode: { type: 'string', example: 'OAUTH__' },
+      message: { type: 'string', example: '응답코드에 맞는 메시지' },
+      statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
+    },
+  },
+})
+@ApiResponse({
+  description: '예상치 못한 Http Exception',
+  schema: {
+    type: 'object',
+    properties: {
+      customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
+      message: { type: 'string', example: 'message from nest' },
+      statusCode: { type: 'number', example: HttpStatus.NOT_FOUND },
+    },
+  },
+})
+@ApiResponse({
+  status: HttpStatus.INTERNAL_SERVER_ERROR,
+  description: '예상치 못한 서버 Exception',
+  schema: {
+    type: 'object',
+    properties: {
+      customCode: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
+      message: { type: 'string', example: 'message from nest' },
+      statusCode: { type: 'number', example: HttpStatus.INTERNAL_SERVER_ERROR },
+    },
+  },
+})
 export class OauthController {
   constructor(private readonly oauthService: OauthService) {}
 
+  @ApiOperation({
+    summary: '카카오 로그인',
+    description: '카카오 로그인을 수행합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '카카오 로그인 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(TokenResDto) },
+      },
+    },
+  })
   @Post('kakao')
-  async processKakaoLogin(@Body('accessToken') accessToken: string) {
+  async processKakaoLogin(@Body() kakaoLoginDto: KakaoLoginDto) {
     // memberHash 구하기
-    const memberHash = await this.oauthService.getKakaoMemberHash(accessToken);
+    const memberHash = await this.oauthService.getKakaoMemberHash(
+      kakaoLoginDto.accessToken,
+    );
 
     // login
     const { accessJWT, refreshJWT } = await this.oauthService.login(memberHash);
 
     // return access token and refresh token
-    throw new CustomResponse(ECustomCode.SUCCESS, {
-      accessToken: accessJWT,
-      refreshToken: refreshJWT,
-    });
+    throw new CustomResponse(
+      ECustomCode.SUCCESS,
+      new TokenResDto(accessJWT, refreshJWT),
+    );
   }
 
+  @ApiOperation({
+    summary: '애플 로그인',
+    description: '애플 로그인을 수행합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '애플 로그인 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(TokenResDto) },
+      },
+    },
+  })
   @Post('apple')
-  async processAppleLogin(@Body('identityToken') identityToken: string) {
+  async processAppleLogin(@Body() appleLoginDto: AppleLoginDto) {
     // memberHash 구하기
-    const memberHash = this.oauthService.getAppleMemberHash(identityToken);
+    const memberHash = this.oauthService.getAppleMemberHash(
+      appleLoginDto.identityToken,
+    );
 
     // login
     const { accessJWT, refreshJWT } = await this.oauthService.login(memberHash);
@@ -39,11 +124,30 @@ export class OauthController {
     });
   }
 
+  @ApiOperation({
+    summary: '카카오 회원가입',
+    description: '카카오 회원가입을 수행합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '카카오 회원가입 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(TokenResDto) },
+      },
+    },
+  })
   @Post('signup/kakao')
-  async processKakaoSignup(
-    @Body('accessToken') accessToken: string,
-    @Body('username') username: string,
-  ) {
+  async processKakaoSignup(@Body() kakaoSignupDto: KakaoSignupDto) {
+    const [accessToken, username] = [
+      kakaoSignupDto.accessToken,
+      kakaoSignupDto.username,
+    ];
+
     // memberHash 구하기
     const memberHash = await this.oauthService.getKakaoMemberHash(accessToken);
 
@@ -63,11 +167,30 @@ export class OauthController {
     });
   }
 
+  @ApiOperation({
+    summary: '애플 회원가입',
+    description: '애플 회원가입을 수행합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '애플 회원가입 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(TokenResDto) },
+      },
+    },
+  })
   @Post('signup/apple')
-  async processAppleSignup(
-    @Body('identityToken') identityToken: string,
-    @Body('username') username: string,
-  ) {
+  async processAppleSignup(@Body() appleSignupDto: AppleSignupDto) {
+    const [identityToken, username] = [
+      appleSignupDto.identityToken,
+      appleSignupDto.username,
+    ];
+
     // memberHash 구하기
     const memberHash = this.oauthService.getAppleMemberHash(identityToken);
 
@@ -87,6 +210,23 @@ export class OauthController {
     });
   }
 
+  @ApiOperation({
+    summary: 'Access token 재발급',
+    description: 'refresh token을 이용해 access token을 재발급합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '토큰 재발급 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'SUCCESS' },
+        message: { type: 'string', example: '성공' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
+        data: { $ref: getSchemaPath(TokenResDto) },
+      },
+    },
+  })
   @Post('refresh-token')
   async renewTokens(@Body('refreshToken', JwtValidationPipe) refreshToken) {
     // 새로운 토큰을 생성하고 이를 반환함

--- a/BE/layover/src/response/custom-response.ts
+++ b/BE/layover/src/response/custom-response.ts
@@ -7,9 +7,17 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { ECustomCode } from './ecustom-code.jenum.';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CustomResponse extends HttpException {
+  @ApiProperty({
+    example: 'LAYOVER01',
+    description: '커스텀 코드',
+  })
   customCode: string;
+  @ApiProperty({
+    description: '응답 데이터',
+  })
   data?: any;
 
   constructor(customException: ECustomCode, data?: any) {


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- controller 스웨거 작성
- 기존 방식에서 dto 방식 변경

#### 📌 변경 사항
- controller 의 메소드마다 swagger 정보 작성
- req body, 성공, 응답 등 명시
- 기존의 Body() 와 변수를 사용한 방식에서 dto 방식으로 변경. 
  - @ApiProperty 나 @ApiResponse 등의 데코레이터를 사용할려면 dto를 사용하는게 훨씬 깔끔해서 변경함

- 공통되는 에러 응답을 api마다 설정해두면 불편해서 어떻게 하면 좋을지 고민중

##### 📸 ScreenShot

![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/18b915d5-3048-4b18-9a0a-58eb892c4b92)

![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/f1cc331c-d9e1-48a0-b259-179a4d5b5629)

![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/f4b585ba-364d-4718-bca1-3290d5173708)

![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/9d72e589-e577-45af-9150-91a83e99618f)

