### PR TITLE
feat: 카카오 로그인 로직 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -206,12 +206,12 @@
 		194551EB2B037F1E00299768 /* Login */ = {
 			isa = PBXGroup;
 			children = (
-				194551EC2B037F2D00299768 /* LoginPresenter.swift */,
 				194551ED2B037F2D00299768 /* LoginWorker.swift */,
-				194551EE2B037F2D00299768 /* LoginRouter.swift */,
 				194551EF2B037F2D00299768 /* LoginModels.swift */,
+				194551EE2B037F2D00299768 /* LoginRouter.swift */,
 				194551F02B037F2D00299768 /* LoginViewController.swift */,
 				194551F12B037F2D00299768 /* LoginInteractor.swift */,
+				194551EC2B037F2D00299768 /* LoginPresenter.swift */,
 				835A61A82B0B5A31002F22A5 /* LoginConfigurator.swift */,
 			);
 			path = Login;

--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		194552312B04DA1A00299768 /* LOCircleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194552302B04DA1A00299768 /* LOCircleButton.swift */; };
 		194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */; };
 		1945523B2B05258200299768 /* HomeConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1945523A2B05258200299768 /* HomeConfigurator.swift */; };
+		1972CCCF2B12438900C3C762 /* LoginEndPointsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */; };
 		19743C052B06940D001E405A /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19743C042B06940D001E405A /* PlayerView.swift */; };
 		19AACFCA2B0F7C3B0088143E /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AACFC92B0F7C3B0088143E /* Response.swift */; };
 		19AACFCC2B0F7D730088143E /* LoginDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AACFCB2B0F7D730088143E /* LoginDTO.swift */; };
@@ -119,6 +120,7 @@
 		194552302B04DA1A00299768 /* LOCircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOCircleButton.swift; sourceTree = "<group>"; };
 		194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
 		1945523A2B05258200299768 /* HomeConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeConfigurator.swift; sourceTree = "<group>"; };
+		1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndPointsFactory.swift; sourceTree = "<group>"; };
 		19743C042B06940D001E405A /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
 		19AACFC52B0F71DF0088143E /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		19AACFC92B0F7C3B0088143E /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
@@ -247,6 +249,14 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		1972CCCD2B12436300C3C762 /* Factories */ = {
+			isa = PBXGroup;
+			children = (
+				1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */,
+			);
+			path = Factories;
+			sourceTree = "<group>";
+		};
 		19AACFC82B0F7C200088143E /* DTOs */ = {
 			isa = PBXGroup;
 			children = (
@@ -284,6 +294,7 @@
 		19C7AFD12B024439003B35F2 /* EndPoint */ = {
 			isa = PBXGroup;
 			children = (
+				1972CCCD2B12436300C3C762 /* Factories */,
 				FC68E29A2B02325D001AABFF /* Requestable.swift */,
 				FC68E29C2B02326A001AABFF /* Responsable.swift */,
 				FC68E29E2B023315001AABFF /* HTTPMethod.swift */,
@@ -660,6 +671,7 @@
 				194551F32B037F2D00299768 /* LoginWorker.swift in Sources */,
 				835A61902B067D61002F22A5 /* LOSlider.swift in Sources */,
 				19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */,
+				1972CCCF2B12438900C3C762 /* LoginEndPointsFactory.swift in Sources */,
 				835A61A92B0B5A31002F22A5 /* LoginConfigurator.swift in Sources */,
 				194551F72B037F2D00299768 /* LoginInteractor.swift in Sources */,
 				FC7E453C2AFEB623004F155A /* SceneDelegate.swift in Sources */,

--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */; };
 		1945523B2B05258200299768 /* HomeConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1945523A2B05258200299768 /* HomeConfigurator.swift */; };
 		1972CCCF2B12438900C3C762 /* LoginEndPointsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */; };
+		1972CCD22B125ED700C3C762 /* UserDefaultStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972CCD12B125ED700C3C762 /* UserDefaultStored.swift */; };
 		19743C052B06940D001E405A /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19743C042B06940D001E405A /* PlayerView.swift */; };
 		19AACFCA2B0F7C3B0088143E /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AACFC92B0F7C3B0088143E /* Response.swift */; };
 		19AACFCC2B0F7D730088143E /* LoginDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AACFCB2B0F7D730088143E /* LoginDTO.swift */; };
@@ -121,6 +122,7 @@
 		194552382B05230E00299768 /* HomeCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
 		1945523A2B05258200299768 /* HomeConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeConfigurator.swift; sourceTree = "<group>"; };
 		1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndPointsFactory.swift; sourceTree = "<group>"; };
+		1972CCD12B125ED700C3C762 /* UserDefaultStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultStored.swift; sourceTree = "<group>"; };
 		19743C042B06940D001E405A /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
 		19AACFC52B0F71DF0088143E /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		19AACFC92B0F7C3B0088143E /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
@@ -255,6 +257,14 @@
 				1972CCCE2B12438900C3C762 /* LoginEndPointsFactory.swift */,
 			);
 			path = Factories;
+			sourceTree = "<group>";
+		};
+		1972CCD02B125E8800C3C762 /* UserDefaults */ = {
+			isa = PBXGroup;
+			children = (
+				1972CCD12B125ED700C3C762 /* UserDefaultStored.swift */,
+			);
+			path = UserDefaults;
 			sourceTree = "<group>";
 		};
 		19AACFC82B0F7C200088143E /* DTOs */ = {
@@ -409,6 +419,7 @@
 		FC7E45752AFF6F5B004F155A /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				1972CCD02B125E8800C3C762 /* UserDefaults */,
 				19C7AFD42B02583C003B35F2 /* Keychain */,
 			);
 			path = Services;
@@ -641,6 +652,7 @@
 				FC4975992B03439000D8627F /* UIFont+.swift in Sources */,
 				194551F52B037F2D00299768 /* LoginModels.swift in Sources */,
 				835A619E2B068115002F22A5 /* PlaybackWorker.swift in Sources */,
+				1972CCD22B125ED700C3C762 /* UserDefaultStored.swift in Sources */,
 				FC2511AD2B04EACD004717BC /* MapInteractor.swift in Sources */,
 				19C7AFD62B02584D003B35F2 /* KeychainStored.swift in Sources */,
 				FC930E802B0CFB0B00AA48E3 /* ProfileHeaderView.swift in Sources */,

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -12,8 +12,12 @@ protocol AuthManagerProtocol {
 
 final class AuthManager: AuthManagerProtocol {
 
+    // MARK: Properties
+
     @KeychainStored(key: "accessToken") var accessToken: String?
     @KeychainStored(key: "refreshToken") var refreshToken: String?
+
+    @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool
 
     static let shared = AuthManager()
 

--- a/iOS/Layover/Layover/Network/EndPoint/EndPoint.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/EndPoint.swift
@@ -24,7 +24,7 @@ final class EndPoint<R>: RequestResponsable {
          method: HTTPMethod,
          queryParameters: Encodable? = nil,
          bodyParameters: Encodable? = nil,
-         headers: [String: String]? = nil) {
+         headers: [String: String]? = ["Content-Type": "application/json"]) {
         self.baseURL = baseURL
         self.path = path
         self.method = method

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointsFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointsFactory.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol LoginEndPointFactory {
     func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>>
+    func makeKakaoSignUpEndPoint(socialToken: String, username: String) -> EndPoint<Response<LoginDTO>>
 }
 
 struct DefaultLoginEndPointsFactory: LoginEndPointFactory {
@@ -19,6 +20,18 @@ struct DefaultLoginEndPointsFactory: LoginEndPointFactory {
 
         return EndPoint(
             path: "/oauth/kakao",
+            method: .POST,
+            bodyParameters: bodyParameters
+        )
+    }
+
+    func makeKakaoSignUpEndPoint(socialToken: String, username: String) -> EndPoint<Response<LoginDTO>> {
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(socialToken, forKey: "accessToken")
+        bodyParameters.updateValue(username, forKey: "username")
+
+        return EndPoint(
+            path: "/oauth/signup/kakao",
             method: .POST,
             bodyParameters: bodyParameters
         )

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointsFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointsFactory.swift
@@ -1,0 +1,26 @@
+//
+//  LoginEndPointsFactory.swift
+//  Layover
+//
+//  Created by 김인환 on 11/26/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+protocol LoginEndPointFactory {
+    func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>>
+}
+
+struct DefaultLoginEndPointsFactory: LoginEndPointFactory {
+    func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>> {
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(socialToken, forKey: "accessToken")
+
+        return EndPoint(
+            path: "/oauth/kakao",
+            method: .POST,
+            bodyParameters: bodyParameters
+        )
+    }
+}

--- a/iOS/Layover/Layover/Resources/Assets.xcassets/appleLogo.imageset/Contents.json
+++ b/iOS/Layover/Layover/Resources/Assets.xcassets/appleLogo.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/iOS/Layover/Layover/Resources/Assets.xcassets/kakaoLogo.imageset/Contents.json
+++ b/iOS/Layover/Layover/Resources/Assets.xcassets/kakaoLogo.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/iOS/Layover/Layover/SceneDelegate.swift
+++ b/iOS/Layover/Layover/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainTabBarViewController()
+        window.rootViewController = UINavigationController(rootViewController: LoginViewController())
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
@@ -26,10 +26,8 @@ class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
     // MARK: - Routing
 
     func routeToNext() {
-        // let destinationVC = UIStoryboard(name: "", bundle: nil).instantiateViewController(withIdentifier: "") as! NextViewController
-        // var destinationDS = destinationVC.router!.dataStore!
-        // passDataTo(destinationDS, from: dataStore!)
-        // viewController?.navigationController?.pushViewController(destinationVC, animated: true)
+        let nextViewController = MainTabBarViewController()
+        viewController?.navigationController?.setViewControllers([nextViewController], animated: true)
     }
 
     // MARK: - Data Passing

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -20,6 +20,8 @@ final class LoginConfigurator: Configurator {
         let interactor = LoginInteractor()
         let presenter = LoginPresenter()
         let worker = LoginWorker(provider: Provider())
+        let router = LoginRouter()
+        viewController.interactor = interactor
         interactor.presenter = presenter
         interactor.worker = worker
         presenter.viewController = viewController

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -21,10 +21,13 @@ final class LoginConfigurator: Configurator {
         let presenter = LoginPresenter()
         let worker = LoginWorker()
         let router = LoginRouter()
+
+        router.viewController = viewController
+        router.dataStore = interactor
         viewController.interactor = interactor
+        viewController.router = router
         interactor.presenter = presenter
         interactor.worker = worker
         presenter.viewController = viewController
-        router.dataStore = interactor
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -19,7 +19,7 @@ final class LoginConfigurator: Configurator {
         let viewController = viewController
         let interactor = LoginInteractor()
         let presenter = LoginPresenter()
-        let worker = LoginWorker(provider: Provider())
+        let worker = LoginWorker()
         let router = LoginRouter()
         viewController.interactor = interactor
         interactor.presenter = presenter

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -19,7 +19,7 @@ final class LoginConfigurator: Configurator {
         let viewController = viewController
         let interactor = LoginInteractor()
         let presenter = LoginPresenter()
-        let worker = LoginWorker()
+        let worker = LoginWorker(provider: Provider())
         interactor.presenter = presenter
         interactor.worker = worker
         presenter.viewController = viewController

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -25,5 +25,6 @@ final class LoginConfigurator: Configurator {
         interactor.presenter = presenter
         interactor.worker = worker
         presenter.viewController = viewController
+        router.dataStore = interactor
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -20,7 +20,7 @@ final class LoginInteractor {
 
     typealias Models = LoginModels
 
-    var worker: LoginWorker?
+    var worker: LoginWorkerProtocol?
     var presenter: LoginPresentationLogic?
 
 }
@@ -29,7 +29,11 @@ final class LoginInteractor {
 
 extension LoginInteractor: LoginBusinessLogic {
     func performKakaoLogin(with request: LoginModels.PerformKakaoLogin.Request) {
-        // TODO: Logic 작성
+        Task {
+            if await worker?.kakaoLogin() == true {
+                presenter?.presentPerformKakaoLogin(with: .init())
+            }
+        }
     }
 
     func performAppleLogin(with request: LoginModels.PerformAppleLogin.Request) {

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -12,9 +12,12 @@ protocol LoginBusinessLogic {
     func performAppleLogin(with request: LoginModels.PerformAppleLogin.Request)
 }
 
-protocol LoginDataStore { }
+protocol LoginDataStore {
+    var kakaoLoginToken: String? { get set }
+    var appleLoginToken: String? { get set }
+}
 
-final class LoginInteractor {
+final class LoginInteractor: LoginDataStore {
 
     // MARK: - Properties
 
@@ -23,6 +26,10 @@ final class LoginInteractor {
     var worker: LoginWorkerProtocol?
     var presenter: LoginPresentationLogic?
 
+    // MARK: Data Store
+
+    var kakaoLoginToken: String?
+    var appleLoginToken: String?
 }
 
 // MARK: - Use Case - Login
@@ -30,8 +37,12 @@ final class LoginInteractor {
 extension LoginInteractor: LoginBusinessLogic {
     func performKakaoLogin(with request: LoginModels.PerformKakaoLogin.Request) {
         Task {
-            if await worker?.kakaoLogin() == true {
+            guard let token = await worker?.fetchKakaoLoginToken() else { return }
+            kakaoLoginToken = token
+            if await worker?.isRegisteredKakao(with: token) == true {
                 presenter?.presentPerformKakaoLogin(with: .init())
+            } else {
+                presenter?.presentSignUp(with: Models.PerformKakaoLogin.Response())
             }
         }
     }
@@ -39,9 +50,5 @@ extension LoginInteractor: LoginBusinessLogic {
     func performAppleLogin(with request: LoginModels.PerformAppleLogin.Request) {
         // TODO: Logic 작성
     }
-
-}
-
-extension LoginInteractor: LoginDataStore {
 
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -39,7 +39,7 @@ extension LoginInteractor: LoginBusinessLogic {
         Task {
             guard let token = await worker?.fetchKakaoLoginToken() else { return }
             kakaoLoginToken = token
-            if await worker?.isRegisteredKakao(with: token) == true {
+            if await worker?.isRegisteredKakao(with: token) == true, await worker?.loginKakao(with: token) == true {
                 presenter?.presentPerformKakaoLogin(with: .init())
             } else {
                 presenter?.presentSignUp(with: Models.PerformKakaoLogin.Response())

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -40,9 +40,13 @@ extension LoginInteractor: LoginBusinessLogic {
             guard let token = await worker?.fetchKakaoLoginToken() else { return }
             kakaoLoginToken = token
             if await worker?.isRegisteredKakao(with: token) == true, await worker?.loginKakao(with: token) == true {
-                presenter?.presentPerformKakaoLogin(with: .init())
+                await MainActor.run {
+                    presenter?.presentPerformLogin()
+                }
             } else {
-                presenter?.presentSignUp(with: Models.PerformKakaoLogin.Response())
+                await MainActor.run {
+                    presenter?.presentSignUp(with: Models.PerformKakaoLogin.Response())
+                }
             }
         }
     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
@@ -13,11 +13,10 @@ enum LoginModels {
 
     enum PerformKakaoLogin {
         struct Request {
-
         }
 
         struct Response {
-
+            
         }
 
         struct ViewModel {

--- a/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
@@ -33,7 +33,7 @@ enum LoginModels {
 
         }
 
-        struct ViewMdoel {
+        struct ViewModel {
 
         }
     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
@@ -9,7 +9,10 @@ import UIKit
 
 protocol LoginPresentationLogic {
     func presentPerformKakaoLogin(with response: LoginModels.PerformKakaoLogin.Response)
+    func presentSignUp(with response: LoginModels.PerformKakaoLogin.Response)
+
     func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response)
+    func presentSignUp(with response: LoginModels.PerformAppleLogin.Response)
 }
 
 final class LoginPresenter {
@@ -29,8 +32,16 @@ extension LoginPresenter: LoginPresentationLogic {
         viewController?.displayPerformKakaoLogin(with: .init())
     }
 
+    func presentSignUp(with response: LoginModels.PerformKakaoLogin.Response) {
+        viewController?.routeToSignUp(with: .init())
+    }
+
     func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response) {
         // TODO: Logic 작성
+    }
+
+    func presentSignUp(with response: LoginModels.PerformAppleLogin.Response) {
+        viewController?.routeToSignUp(with: .init())
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
@@ -28,7 +28,7 @@ extension LoginPresenter: LoginPresentationLogic {
         // TODO: Logic 작성
         viewController?.displayPerformKakaoLogin(with: .init())
     }
-    
+
     func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response) {
         // TODO: Logic 작성
     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
@@ -8,10 +8,8 @@
 import UIKit
 
 protocol LoginPresentationLogic {
-    func presentPerformKakaoLogin(with response: LoginModels.PerformKakaoLogin.Response)
+    func presentPerformLogin()
     func presentSignUp(with response: LoginModels.PerformKakaoLogin.Response)
-
-    func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response)
     func presentSignUp(with response: LoginModels.PerformAppleLogin.Response)
 }
 
@@ -27,21 +25,15 @@ final class LoginPresenter {
 // MARK: - Use Case - Login
 
 extension LoginPresenter: LoginPresentationLogic {
-    func presentPerformKakaoLogin(with response: LoginModels.PerformKakaoLogin.Response) {
-        // TODO: Logic 작성
-        viewController?.displayPerformKakaoLogin(with: .init())
+    func presentPerformLogin() {
+        viewController?.navigateToMain()
     }
 
     func presentSignUp(with response: LoginModels.PerformKakaoLogin.Response) {
-        viewController?.routeToSignUp(with: .init())
-    }
-
-    func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response) {
-        // TODO: Logic 작성
+        viewController?.routeToSignUp(with: LoginModels.PerformKakaoLogin.ViewModel())
     }
 
     func presentSignUp(with response: LoginModels.PerformAppleLogin.Response) {
-        viewController?.routeToSignUp(with: .init())
+        viewController?.routeToSignUp(with: LoginModels.PerformAppleLogin.ViewModel())
     }
-
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginPresenter.swift
@@ -26,7 +26,7 @@ final class LoginPresenter {
 extension LoginPresenter: LoginPresentationLogic {
     func presentPerformKakaoLogin(with response: LoginModels.PerformKakaoLogin.Response) {
         // TODO: Logic 작성
-
+        viewController?.displayPerformKakaoLogin(with: .init())
     }
     
     func presentPerformAppleLogin(with response: LoginModels.PerformAppleLogin.Response) {

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -9,13 +9,15 @@ import UIKit
 
 protocol LoginRoutingLogic {
     func routeToMainTabBar()
+    func navigateToKakaoSignUp()
+    func navigateToAppleSignUp()
 }
 
 protocol LoginDataPassing {
     var dataStore: LoginDataStore? { get }
 }
 
-class LoginRouter: NSObject, LoginRoutingLogic, LoginDataPassing {
+final class LoginRouter: NSObject, LoginRoutingLogic, LoginDataPassing {
 
     // MARK: - Properties
 
@@ -27,5 +29,17 @@ class LoginRouter: NSObject, LoginRoutingLogic, LoginDataPassing {
     func routeToMainTabBar() {
         let tabBarViewController = MainTabBarViewController()
         viewController?.navigationController?.setViewControllers([tabBarViewController], animated: true)
+    }
+
+    func navigateToKakaoSignUp() {
+        // TODO: SignUpRouter로 토큰 값 전달 필요
+        let signUpViewController = SignUpViewController()
+        viewController?.navigationController?.pushViewController(signUpViewController, animated: true)
+    }
+
+    func navigateToAppleSignUp() {
+        // TODO: SignUpRouter로 토큰 값 전달 필요
+        let signUpViewController = SignUpViewController()
+        viewController?.navigationController?.pushViewController(signUpViewController, animated: true)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol LoginRoutingLogic {
-    func routeToNext()
+    func routeToMainTabBar()
 }
 
 protocol LoginDataPassing {
@@ -24,8 +24,8 @@ class LoginRouter: NSObject, LoginRoutingLogic, LoginDataPassing {
 
     // MARK: - Routing
 
-    func routeToNext() {
-
+    func routeToMainTabBar() {
+        let tabBarViewController = MainTabBarViewController()
+        viewController?.navigationController?.setViewControllers([tabBarViewController], animated: true)
     }
-
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -16,6 +16,7 @@ protocol LoginDisplayLogic: AnyObject {
 final class LoginViewController: BaseViewController {
 
     // MARK: - Properties
+
     private let logoImage: UIImageView = {
         let imageView: UIImageView = UIImageView()
         imageView.image = UIImage.loLogo
@@ -29,51 +30,39 @@ final class LoginViewController: BaseViewController {
         return titleLabel
     }()
 
-    private let kakaoTitleView: UIView = UIView()
-
-    private let kakaoLogo: UIImageView = {
-        let imageView: UIImageView = UIImageView()
-        imageView.image = UIImage.kakaoLogo
-        return imageView
-    }()
-
-    private let kakaoLabel: UILabel = {
-        let label: UILabel = UILabel()
-        label.text = "카카오로 계속하기"
-        label.font = UIFont.boldSystemFont(ofSize: 17)
-        label.textColor = .black
-        return label
-    }()
-
     private let kakaoLoginButton: UIButton = {
-        let button: UIButton = UIButton()
-        button.backgroundColor = .kakao
+        var configuration = UIButton.Configuration.filled()
+        configuration.baseBackgroundColor = .kakao
+
+        configuration.attributedTitle = AttributedString("카카오로 계속하기",
+                                                         attributes: AttributeContainer([.font: UIFont.boldSystemFont(ofSize: 17),
+                                                                                         .foregroundColor: UIColor.black]))
+        configuration.image = UIImage.kakaoLogo.resized(to: CGSize(width: 20, height: 20))
+        configuration.imagePadding = 4
+        configuration.contentInsets = .init(top: 0, leading: -4, bottom: 0, trailing: 0)
+        let button: UIButton = UIButton(configuration: configuration)
+        button.clipsToBounds = true
         button.layer.cornerRadius = 10
         return button
-    }()
-
-    private let appleTitleView: UIView = UIView()
-
-    private let appleLabel: UILabel = {
-        let label: UILabel = UILabel()
-        label.text = "Apple로 계속하기"
-        label.font = UIFont.boldSystemFont(ofSize: 17)
-        label.textColor = .black
-        return label
-    }()
-
-    private let appleLogo: UIImageView = {
-        let imageView: UIImageView = UIImageView()
-        imageView.image = UIImage.appleLogo
-        return imageView
     }()
 
     private let appleLoginButton: UIButton = {
-        let button: UIButton = UIButton()
-        button.backgroundColor = .white
+        var configuration = UIButton.Configuration.filled()
+        configuration.baseBackgroundColor = .white
+
+        configuration.attributedTitle = AttributedString("Apple로 계속하기",
+                                                         attributes: AttributeContainer([.font: UIFont.boldSystemFont(ofSize: 17),
+                                                                                         .foregroundColor: UIColor.black]))
+
+        configuration.image = UIImage.appleLogo.resized(to: CGSize(width: 20, height: 20))
+        configuration.imagePadding = 4
+        let button: UIButton = UIButton(configuration: configuration)
+        button.clipsToBounds = true
         button.layer.cornerRadius = 10
         return button
     }()
+
+    // MARK: Properties
 
     typealias Models = LoginModels
 
@@ -81,6 +70,7 @@ final class LoginViewController: BaseViewController {
     var router: (LoginRoutingLogic & LoginDataPassing)?
 
     // MARK: - Object lifecycle
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         setup()
@@ -92,6 +82,7 @@ final class LoginViewController: BaseViewController {
     }
 
     // MARK: - Setup
+
     private func setup() {
         LoginConfigurator.shared.configure(self)
     }
@@ -106,61 +97,24 @@ final class LoginViewController: BaseViewController {
 
         NSLayoutConstraint.activate([
             logoImage.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            logoImage.topAnchor.constraint(equalTo: view.topAnchor, constant: 280),
+            logoImage.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 236),
             logoImage.widthAnchor.constraint(equalToConstant: 81.24),
             logoImage.heightAnchor.constraint(equalToConstant: 58.12),
+
             logoTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             logoTitleLabel.topAnchor.constraint(equalTo: logoImage.bottomAnchor, constant: 14.88),
+
             kakaoLoginButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            kakaoLoginButton.topAnchor.constraint(equalTo: logoTitleLabel.bottomAnchor, constant: 81),
+            kakaoLoginButton.topAnchor.constraint(equalTo: logoTitleLabel.bottomAnchor, constant: 77),
             kakaoLoginButton.widthAnchor.constraint(equalToConstant: 315),
             kakaoLoginButton.heightAnchor.constraint(equalToConstant: 48),
+
             appleLoginButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             appleLoginButton.topAnchor.constraint(equalTo: kakaoLoginButton.bottomAnchor, constant: 8),
             appleLoginButton.widthAnchor.constraint(equalToConstant: 315),
             appleLoginButton.heightAnchor.constraint(equalToConstant: 48)
         ])
-        setLoginButtonConstraints()
     }
-
-    private func setLoginButtonConstraints() {
-        [kakaoTitleView, kakaoLogo, kakaoLabel, appleTitleView, appleLogo, appleLabel].forEach { subView in
-            subView.translatesAutoresizingMaskIntoConstraints = false
-        }
-        kakaoTitleView.addSubviews(kakaoLogo, kakaoLabel)
-        kakaoLoginButton.addSubview(kakaoTitleView)
-        appleTitleView.addSubviews(appleLogo, appleLabel)
-        appleLoginButton.addSubview(appleTitleView)
-
-        NSLayoutConstraint.activate([
-            kakaoTitleView.widthAnchor.constraint(equalToConstant: 129),
-            kakaoTitleView.heightAnchor.constraint(equalToConstant: 20),
-            kakaoTitleView.centerXAnchor.constraint(equalTo: kakaoLoginButton.centerXAnchor),
-            kakaoTitleView.centerYAnchor.constraint(equalTo: kakaoLoginButton.centerYAnchor),
-            kakaoLogo.widthAnchor.constraint(equalToConstant: 20),
-            kakaoLogo.heightAnchor.constraint(equalToConstant: 20),
-            kakaoLogo.leadingAnchor.constraint(equalTo: kakaoTitleView.leadingAnchor),
-            kakaoLogo.topAnchor.constraint(equalTo: kakaoTitleView.topAnchor),
-            kakaoLogo.bottomAnchor.constraint(equalTo: kakaoTitleView.bottomAnchor),
-            kakaoLabel.topAnchor.constraint(equalTo: kakaoTitleView.topAnchor),
-            kakaoLabel.bottomAnchor.constraint(equalTo: kakaoTitleView.bottomAnchor),
-            kakaoLabel.leadingAnchor.constraint(equalTo: kakaoLogo.trailingAnchor, constant: 1.5),
-
-            appleTitleView.widthAnchor.constraint(equalToConstant: 129),
-            appleTitleView.heightAnchor.constraint(equalToConstant: 20),
-            appleTitleView.centerXAnchor.constraint(equalTo: appleLoginButton.centerXAnchor),
-            appleTitleView.centerYAnchor.constraint(equalTo: appleLoginButton.centerYAnchor),
-            appleLogo.widthAnchor.constraint(equalToConstant: 20),
-            appleLogo.heightAnchor.constraint(equalToConstant: 20),
-            appleLogo.leadingAnchor.constraint(equalTo: appleTitleView.leadingAnchor),
-            appleLogo.topAnchor.constraint(equalTo: appleTitleView.topAnchor),
-            appleLogo.bottomAnchor.constraint(equalTo: appleTitleView.bottomAnchor),
-            appleLabel.topAnchor.constraint(equalTo: appleTitleView.topAnchor),
-            appleLabel.bottomAnchor.constraint(equalTo: appleTitleView.bottomAnchor),
-            appleLabel.leadingAnchor.constraint(equalTo: appleLogo.trailingAnchor, constant: 1.5)
-        ])
-    }
-
 }
 
 // MARK: - Use Case - Login
@@ -168,7 +122,6 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController: LoginDisplayLogic {
     func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
         // TODO: Logic 작성
-        print("HELLO")
         router?.routeToNext()
     }
 
@@ -178,6 +131,10 @@ extension LoginViewController: LoginDisplayLogic {
 
 }
 
-#Preview {
-    LoginViewController()
+fileprivate extension UIImage {
+    func resized(to size: CGSize) -> UIImage {
+        return UIGraphicsImageRenderer(size: size).image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -10,6 +10,7 @@ import AuthenticationServices
 
 protocol LoginDisplayLogic: AnyObject {
     func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel)
+    func routeToSignUp(with viewModel: LoginModels.PerformKakaoLogin.ViewModel)
     func displayPerformAppleLogin(with viewModel: LoginModels.PerformAppleLogin.ViewMdoel)
 }
 
@@ -136,7 +137,12 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController: LoginDisplayLogic {
     func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
         // TODO: Logic 작성
-        router?.routeToNext()
+        router?.routeToMainTabBar()
+    }
+
+    func routeToSignUp(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
+        // TODO: 로그인 후 회원가입이 필요한 경우
+//         router?.routeToMainTabBar()
     }
 
     func displayPerformAppleLogin(with viewModel: LoginModels.PerformAppleLogin.ViewMdoel) {

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -78,6 +78,7 @@ final class LoginViewController: BaseViewController {
     typealias Models = LoginModels
 
     var interactor: LoginBusinessLogic?
+    var router: (LoginRoutingLogic & LoginDataPassing)?
 
     // MARK: - Object lifecycle
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -167,6 +168,8 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController: LoginDisplayLogic {
     func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
         // TODO: Logic 작성
+        print("HELLO")
+        router?.routeToNext()
     }
 
     func displayPerformAppleLogin(with viewModel: LoginModels.PerformAppleLogin.ViewMdoel) {

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -30,7 +30,7 @@ final class LoginViewController: BaseViewController {
         return titleLabel
     }()
 
-    private let kakaoLoginButton: UIButton = {
+    private lazy var kakaoLoginButton: UIButton = {
         var configuration = UIButton.Configuration.filled()
         configuration.baseBackgroundColor = .kakao
 
@@ -41,12 +41,13 @@ final class LoginViewController: BaseViewController {
         configuration.imagePadding = 4
         configuration.contentInsets = .init(top: 0, leading: -4, bottom: 0, trailing: 0)
         let button: UIButton = UIButton(configuration: configuration)
+        button.addTarget(self, action: #selector(kakaoLoginButtonTapped(_:)), for: .touchUpInside)
         button.clipsToBounds = true
         button.layer.cornerRadius = 10
         return button
     }()
 
-    private let appleLoginButton: UIButton = {
+    private lazy var appleLoginButton: UIButton = {
         var configuration = UIButton.Configuration.filled()
         configuration.baseBackgroundColor = .white
 
@@ -57,6 +58,7 @@ final class LoginViewController: BaseViewController {
         configuration.image = UIImage.appleLogo.resized(to: CGSize(width: 20, height: 20))
         configuration.imagePadding = 4
         let button: UIButton = UIButton(configuration: configuration)
+        button.addTarget(self, action: #selector(appleLoginButtonTapped(_:)), for: .touchUpInside)
         button.clipsToBounds = true
         button.layer.cornerRadius = 10
         return button
@@ -114,6 +116,18 @@ final class LoginViewController: BaseViewController {
             appleLoginButton.widthAnchor.constraint(equalToConstant: 315),
             appleLoginButton.heightAnchor.constraint(equalToConstant: 48)
         ])
+    }
+
+    // MARK: Actions
+
+    @objc private func kakaoLoginButtonTapped(_ sender: UIButton) {
+        let request = LoginModels.PerformKakaoLogin.Request()
+        interactor?.performKakaoLogin(with: request)
+    }
+
+    @objc private func appleLoginButtonTapped(_ sender: UIButton) {
+        let request = LoginModels.PerformAppleLogin.Request()
+        interactor?.performAppleLogin(with: request)
     }
 }
 

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -9,9 +9,9 @@ import UIKit
 import AuthenticationServices
 
 protocol LoginDisplayLogic: AnyObject {
-    func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel)
+    func navigateToMain()
     func routeToSignUp(with viewModel: LoginModels.PerformKakaoLogin.ViewModel)
-    func displayPerformAppleLogin(with viewModel: LoginModels.PerformAppleLogin.ViewMdoel)
+    func routeToSignUp(with viewModel: LoginModels.PerformAppleLogin.ViewModel)
 }
 
 final class LoginViewController: BaseViewController {
@@ -135,20 +135,17 @@ final class LoginViewController: BaseViewController {
 // MARK: - Use Case - Login
 
 extension LoginViewController: LoginDisplayLogic {
-    func displayPerformKakaoLogin(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
-        // TODO: Logic 작성
+    func navigateToMain() {
         router?.routeToMainTabBar()
     }
 
     func routeToSignUp(with viewModel: LoginModels.PerformKakaoLogin.ViewModel) {
-        // TODO: 로그인 후 회원가입이 필요한 경우
-//         router?.routeToMainTabBar()
+        router?.navigateToKakaoSignUp()
     }
 
-    func displayPerformAppleLogin(with viewModel: LoginModels.PerformAppleLogin.ViewMdoel) {
-        // TODO: Logic 작성
+    func routeToSignUp(with viewModel: LoginModels.PerformAppleLogin.ViewModel) {
+        router?.navigateToAppleSignUp()
     }
-
 }
 
 fileprivate extension UIImage {

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -30,7 +30,7 @@ final class LoginWorker: LoginWorkerProtocol {
     }
 
     // MARK: - Login Methods
-
+    @MainActor
     private func fetchKakaoLoginToken() async -> String? {
         if UserApi.isKakaoTalkLoginAvailable() {
             return await withCheckedContinuation { continuation in

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -6,18 +6,85 @@
 //
 
 import UIKit
+import KakaoSDKAuth
+import KakaoSDKUser
 
-final class LoginWorker {
+import OSLog
+
+protocol LoginWorkerProtocol {
+    func kakaoLogin() async -> Bool
+}
+
+final class LoginWorker: LoginWorkerProtocol {
 
     // MARK: - Properties
 
     typealias Models = LoginModels
 
+    let provider: ProviderType
+    let authManager: AuthManager
+
+    init(provider: ProviderType, authManager: AuthManager = .shared) {
+        self.provider = provider
+        self.authManager = authManager
+    }
+
     // MARK: - Login Methods
 
+    private func fetchKakaoLoginToken() async -> String? {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            return await withCheckedContinuation { continuation in
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        os_log(.error, log: .data, "%@", error.localizedDescription)
+                        continuation.resume(returning: nil)
+                    } else {
+                        continuation.resume(returning: oauthToken?.accessToken)
+                    }
+                }
+            }
+        } else {
+            return await withCheckedContinuation { continuation in
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                    if let error = error {
+                        os_log(.error, log: .data, "%@", error.localizedDescription)
+                        continuation.resume(returning: nil)
+                    } else {
+                        continuation.resume(returning: oauthToken?.accessToken)
+                    }
+                }
+            }
+        }
+    }
 
-    func kakaoLogin() {
+    func kakaoLogin() async -> Bool {
+        guard let token = await fetchKakaoLoginToken() else {
+            os_log(.error, log: .data, "%@", "Failed to fetch kakao login token")
+            return false
+        }
 
+        guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
+            os_log(.error, log: .data, "%@", "Failed to fetch base url")
+            return false
+        }
+
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(token, forKey: "accessToken")
+
+        let endPoint = EndPoint<Response<LoginDTO>>(baseURL: baseURL,
+                                                    path: "/api/v1/auth/login",
+                                                    method: .POST,
+                                                    bodyParameters: bodyParameters)
+
+        do {
+            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            authManager.accessToken = result.data?.accessToken
+            authManager.refreshToken = result.data?.refreshToken
+            return true
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return false
+        }
     }
 
     func appleLogin() {

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -83,6 +83,7 @@ extension LoginWorker: LoginWorkerProtocol {
 
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken
+            authManager.isLoggedIn = true
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -39,12 +39,12 @@ final class LoginWorker: LoginWorkerProtocol {
             return false
         }
 
-        // TODO: 회원 가입 여부 확인
-
         // 로그인 처리
         do {
             let endPoint = loginEndPointFactory.makeKakaoLoginEndPoint(with: token)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+
+            // TODO: 임시 구현, 추후 서버 바뀌면 회원가입 여부도 API 체크
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken
             return true

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -7,3 +7,27 @@
 //
 
 import Foundation
+
+@propertyWrapper
+struct UserDefaultStored<T> {
+    private let key: String
+    private let defaultValue: T
+
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    var wrappedValue: T {
+        get {
+            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}
+
+enum UserDefaultKey {
+    static let isLoggedIn = "isLoggedIn"
+}

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -1,0 +1,9 @@
+//
+//  UserDefaultStored.swift
+//  Layover
+//
+//  Created by 김인환 on 11/26/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
## 🧑‍🚀 PR 요약

- 로그인 화면 UI 수정
- 카카오 로그인 로직 구현
- EndPoint 팩토리 구현
- UserDefault 래퍼 구현 및 AuthManager에 로그인 여부 프로퍼티 설정

#### 📌 변경 사항

> [!NOTE]
> 로그인 화면 UI를 변경했습니다.

- 버튼위에 라벨과 이미지가 올려져 있어서, 터치가 안되는 버그가 있었습니다. 
- iOS 15.0부터 사용가능한 UIButton.Configuration을 사용해 버튼을 구현하여 해결했습니다.

> [!NOTE]
> LoginEndPointFactory 를 선언했습니다.

- 팩토리 메서드로 EndPoint를 찍어낼 수 있도록 했습니다.
- 필요한 EndPoint들을 미리 설정해두고, Worker에서 사용하시면 될 것 같습니다.
- 다만, Factory 객체 프로퍼티에 대해서는 프로토콜로 추상화해서 의존성 역전 법칙을 지키도록 해주세요.

> [!NOTE]
> 카카오 로그인 로직을 구현했습니다.

- LoginInteractor에서는 큰 트랜잭션 로직을 수행하고, LoginWorker에게 세부적인 로직을 수행하게 하는 흐름입니다.
- 회원가입 여부 판단 API를 제외하고 나머지 부분만 우선 구현했습니다.
- 회원가입 여부에 따라 닉네임 수정 뷰, 로그인 수행 후 홈 뷰 routing으로 분기처리 메서드를 타도록 했습니다.
- 회원가입 완료 까지 처리하려면 SignUpScene의 코드도 수정해야 하기에, 이후 부분은 이슈를 파서 처리하겠습니다.
- 전에 CleanSwift 아키텍처에 대해 공부 할 때, 스레드 관리를 잘 해주어야 한다는 부분이 생각났습니다. 
  - presenter 메서드를 호출 할 때와 카카오 SDK API 메서드를 호출 할 때, MainActor로 처리하면서 그런 부분에 대해 느꼈습니다.
  - Swift Concurrency 공부를 해야겠다는 생각이 강하게 드네요...

##### 📸 ScreenShot
![Simulator Screen Recording - iPhone 15 Pro - 2023-11-26 at 03 09 41](https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/388e13b5-aeb7-4de3-97b9-50bbc7e482c5)


#### Linked Issue
close #85
