### PR TITLE
feat: 애플 로그인 API 요청 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFCD2B02410F003B35F2 /* AuthManager.swift */; };
 		19C7AFD62B02584D003B35F2 /* KeychainStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFD52B02584D003B35F2 /* KeychainStored.swift */; };
 		19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */; };
+		835783C32B14A41600E7D304 /* MockLoginWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835783C22B14A41600E7D304 /* MockLoginWorker.swift */; };
+		835783C62B14A5C800E7D304 /* LoginData.json in Resources */ = {isa = PBXBuildFile; fileRef = 835783C52B14A5C800E7D304 /* LoginData.json */; };
 		835A61902B067D61002F22A5 /* LOSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A618F2B067D61002F22A5 /* LOSlider.swift */; };
 		835A61922B067FEC002F22A5 /* LOTagStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A61912B067FEC002F22A5 /* LOTagStackView.swift */; };
 		835A61942B068096002F22A5 /* LODescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A61932B068096002F22A5 /* LODescriptionView.swift */; };
@@ -153,6 +155,9 @@
 		19C7AFCD2B02410F003B35F2 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		19C7AFD52B02584D003B35F2 /* KeychainStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStored.swift; sourceTree = "<group>"; };
 		19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopingPlayerView.swift; sourceTree = "<group>"; };
+		835783C22B14A41600E7D304 /* MockLoginWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginWorker.swift; sourceTree = "<group>"; };
+		835783C52B14A5C800E7D304 /* LoginData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LoginData.json; sourceTree = "<group>"; };
+		835783C72B14ADB600E7D304 /* Layover.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Layover.entitlements; sourceTree = "<group>"; };
 		835A618F2B067D61002F22A5 /* LOSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOSlider.swift; sourceTree = "<group>"; };
 		835A61912B067FEC002F22A5 /* LOTagStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOTagStackView.swift; sourceTree = "<group>"; };
 		835A61932B068096002F22A5 /* LODescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LODescriptionView.swift; sourceTree = "<group>"; };
@@ -435,6 +440,7 @@
 				FC767F9D2B12283D0088CF9B /* PatchIntroduce.json */,
 				FC767F9E2B12283D0088CF9B /* PatchProfileImage.json */,
 				FC767F9A2B12283D0088CF9B /* PatchUserName.json */,
+				835783C52B14A5C800E7D304 /* LoginData.json */,
 			);
 			path = MockData;
             sourceTree = "<group>";
@@ -471,6 +477,7 @@
 		FC7E45382AFEB623004F155A /* Layover */ = {
 			isa = PBXGroup;
 			children = (
+				835783C72B14ADB600E7D304 /* Layover.entitlements */,
 				FC68E2992B02320F001AABFF /* Network */,
 				FC7E45752AFF6F5B004F155A /* Services */,
 				FC7E45782AFF6F7A004F155A /* Workers */,
@@ -508,6 +515,7 @@
 			children = (
 				FC767F832B1214A70088CF9B /* MockUserWorker.swift */,
 				FC7E458F2AFF746E004F155A /* DummyWorker.swift */,
+				835783C22B14A41600E7D304 /* MockLoginWorker.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -699,6 +707,7 @@
 				FC767F9F2B12283D0088CF9B /* PatchUserName.json in Resources */,
 				FC49758F2B03432800D8627F /* Pretendard-SemiBold.ttf in Resources */,
 				835A61A62B0B4DDD002F22A5 /* Dashboard-Regular.ttf in Resources */,
+				835783C62B14A5C800E7D304 /* LoginData.json in Resources */,
 				FC767FA12B12283D0088CF9B /* DeleteUser.json in Resources */,
 				FC7E45462AFEB62B004F155A /* LaunchScreen.storyboard in Resources */,
 				FC767FA02B12283D0088CF9B /* CheckUserName.json in Resources */,
@@ -781,6 +790,7 @@
 				19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */,
 				FC9BB82C2B094E5500EB72A9 /* UICollectionViewLayout+.swift in Sources */,
 				194552232B0478B400299768 /* HomeRouter.swift in Sources */,
+				835783C32B14A41600E7D304 /* MockLoginWorker.swift in Sources */,
 				835A61922B067FEC002F22A5 /* LOTagStackView.swift in Sources */,
 				FC7E45902AFF746E004F155A /* DummyWorker.swift in Sources */,
 				FC930E7A2B0CD75C00AA48E3 /* ProfileInteractor.swift in Sources */,
@@ -974,6 +984,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Layover/Layover.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
@@ -1004,6 +1015,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Layover/Layover.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;

--- a/iOS/Layover/Layover/Layover.entitlements
+++ b/iOS/Layover/Layover/Layover.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol LoginEndPointFactory {
     func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>>
+    func makeAppleLoginEndPoint(with identityToken: String) -> EndPoint<Response<LoginDTO>>
 }
 
 struct DefaultLoginEndPointFactory: LoginEndPointFactory {
@@ -22,5 +23,16 @@ struct DefaultLoginEndPointFactory: LoginEndPointFactory {
             method: .POST,
             bodyParameters: bodyParameters
         )
+    }
+
+    func makeAppleLoginEndPoint(with identityToken: String) -> EndPoint<Response<LoginDTO>> {
+        var bodyParameters: [String: String] = [String: String]()
+        bodyParameters.updateValue(identityToken, forKey: "identityToken")
+
+        return EndPoint(
+            path: "/oauth/apple",
+            method: .POST,
+            bodyParameters: bodyParameters)
+
     }
 }

--- a/iOS/Layover/Layover/Network/Mock/MockData/LoginData.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/LoginData.json
@@ -1,0 +1,9 @@
+{
+  "customCode": "SUCCESS",
+  "message": "성공",
+  "statusCode": 200,
+  "data": {
+    "accessToken": "mockAccessToken",
+    "refreshToken": "mockRefreshToken"
+  }
+}

--- a/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginConfigurator.swift
@@ -19,7 +19,8 @@ final class LoginConfigurator: Configurator {
         let viewController = viewController
         let interactor = LoginInteractor()
         let presenter = LoginPresenter()
-        let worker = LoginWorker()
+        // TODO: 실행 전 Worker Mock인지 확인
+        let worker = MockLoginWorker()
         let router = LoginRouter()
 
         router.viewController = viewController

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -76,7 +76,10 @@ extension LoginInteractor: ASAuthorizationControllerDelegate {
                 return
             }
             Task {
-                if await worker?.isRegisteredApple(with: identityToken) == true, await worker?.loginApple(with: identityToken) == true {
+                async let isRegistered: Bool = worker?.isRegisteredApple(with: identityToken) ?? false
+                async let loginResult: Bool = worker?.loginApple(with: identityToken) ?? false
+
+                if await isRegistered, await loginResult {
                     await MainActor.run {
                         presenter?.presentPerformLogin()
                     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
@@ -26,7 +26,7 @@ enum LoginModels {
 
     enum PerformAppleLogin {
         struct Request {
-            let loginViewController: LoginViewController = LoginViewController()
+            let loginViewController: LoginViewController
         }
 
         struct Response {

--- a/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginModels.swift
@@ -5,7 +5,7 @@
 //  Created by 김인환 on 11/14/23.
 //
 
-import UIKit
+import Foundation
 
 enum LoginModels {
 
@@ -26,7 +26,7 @@ enum LoginModels {
 
     enum PerformAppleLogin {
         struct Request {
-
+            let loginViewController: LoginViewController = LoginViewController()
         }
 
         struct Response {

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -127,7 +127,7 @@ final class LoginViewController: BaseViewController {
     }
 
     @objc private func appleLoginButtonTapped(_ sender: UIButton) {
-        let request = LoginModels.PerformAppleLogin.Request()
+        let request = LoginModels.PerformAppleLogin.Request(loginViewController: self)
         interactor?.performAppleLogin(with: request)
     }
 }
@@ -158,6 +158,9 @@ fileprivate extension UIImage {
 
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        self.view.window!
+        guard let window: UIWindow = self.view.window else {
+            return ASPresentationAnchor(frame: .zero)
+        }
+        return window
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginViewController.swift
@@ -155,3 +155,9 @@ fileprivate extension UIImage {
         }
     }
 }
+
+extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        self.view.window!
+    }
+}

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -5,9 +5,10 @@
 //  Created by 김인환 on 11/14/23.
 //
 
-import UIKit
+import Foundation
 import KakaoSDKAuth
 import KakaoSDKUser
+import AuthenticationServices
 
 import OSLog
 
@@ -15,9 +16,11 @@ protocol LoginWorkerProtocol {
     @MainActor func fetchKakaoLoginToken() async -> String?
     func isRegisteredKakao(with socialToken: String) async -> Bool
     func loginKakao(with socialToken: String) async -> Bool
+    func isRegisteredApple(with identityToken: String) async -> Bool
+    func loginApple(with identityToken: String) async -> Bool
 }
 
-final class LoginWorker {
+final class LoginWorker: NSObject {
 
     // MARK: - Properties
 
@@ -36,6 +39,7 @@ final class LoginWorker {
 
 extension LoginWorker: LoginWorkerProtocol {
 
+    // MARK: - Kakao Login
     @MainActor
     func fetchKakaoLoginToken() async -> String? {
         if UserApi.isKakaoTalkLoginAvailable() {
@@ -80,6 +84,28 @@ extension LoginWorker: LoginWorkerProtocol {
         do {
             let endPoint = loginEndPointFactory.makeKakaoLoginEndPoint(with: socialToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+
+            authManager.accessToken = result.data?.accessToken
+            authManager.refreshToken = result.data?.refreshToken
+            authManager.isLoggedIn = true
+            return true
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return false
+        }
+    }
+
+    // MARK: - Apple Login
+
+    func isRegisteredApple(with identityToken: String) async -> Bool {
+        // TODO: 회원가입 여부 판단
+        return false
+    }
+
+    func loginApple(with identityToken: String) async -> Bool {
+        do {
+            let endPoint: EndPoint = loginEndPointFactory.makeAppleLoginEndPoint(with: identityToken)
+            let result: EndPoint<Response<LoginDTO>>.Response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
 
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken

--- a/iOS/Layover/Layover/Workers/MockLoginWorker.swift
+++ b/iOS/Layover/Layover/Workers/MockLoginWorker.swift
@@ -1,0 +1,76 @@
+//
+//  MockLoginWorker.swift
+//  Layover
+//
+//  Created by 황지웅 on 11/27/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+import OSLog
+
+final class MockLoginWorker: LoginWorkerProtocol {
+
+    // MARK: - Properties
+
+    private let provider: ProviderType
+    private let loginEndPointFactory: LoginEndPointFactory
+    private let authManager: AuthManager
+
+    init(provider: ProviderType = Provider(session: .initMockSession()), loginEndPointFactory: LoginEndPointFactory = DefaultLoginEndPointFactory(), authManager: AuthManager = .shared) {
+        self.provider = provider
+        self.authManager = authManager
+        self.loginEndPointFactory = loginEndPointFactory
+    }
+
+    private let headers: [String: String] = ["Content-Type": "application/json", "Authorization": "mock token"]
+
+    // MARK: - Methods
+
+    func fetchKakaoLoginToken() async -> String? {
+        // TODO: 로직 구현
+        return nil
+    }
+
+    func isRegisteredKakao(with socialToken: String) async -> Bool {
+        // TODO: 로직 구현
+        return false
+    }
+
+    func loginKakao(with socialToken: String) async -> Bool {
+        // TODO: 로직 구현
+        return false
+    }
+
+    func isRegisteredApple(with identityToken: String) async -> Bool {
+        // TODO: 로직 구현
+        return true
+    }
+
+    func loginApple(with identityToken: String) async -> Bool {
+        guard let fileLocation: URL = Bundle.main.url(forResource: "LoginData", withExtension: "json") else {
+            return false
+        }
+        guard let mockData: Data = try? Data(contentsOf: fileLocation) else {
+            return false
+        }
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)
+            return (response, mockData, nil)
+        }
+        do {
+            let endPoint: EndPoint = loginEndPointFactory.makeAppleLoginEndPoint(with: identityToken)
+            let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            print(response.data?.accessToken ?? "")
+            print(response.data?.refreshToken ?? "")
+            return true
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- [x] 애플 소셜 로그인을 할 수 있다.
애플 소셜 로그인을 할 수 있습니다. 회원가입은 아직 미구현 상태이며 로그인을 성공했다고 가정합니다.

#### 📌 변경 사항
LoginViewController의 Worker를 MockLoginWorker로 변경해놓았습니다. 확인 바랍니다.

##### 📸 ScreenShot

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/08e8a596-4815-4aea-a771-61d9104df7ef


#### Linked Issue
close #56 
