### PR TITLE
feat: 애플 로그인 회원가입 로직 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFCD2B02410F003B35F2 /* AuthManager.swift */; };
 		19C7AFD62B02584D003B35F2 /* KeychainStored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C7AFD52B02584D003B35F2 /* KeychainStored.swift */; };
 		19E79AC02B0A85D0009EA9ED /* LoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */; };
+		834B7BD52B14F888002BD176 /* MockSignUpWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834B7BD42B14F888002BD176 /* MockSignUpWorker.swift */; };
 		835783C32B14A41600E7D304 /* MockLoginWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835783C22B14A41600E7D304 /* MockLoginWorker.swift */; };
 		835783C62B14A5C800E7D304 /* LoginData.json in Resources */ = {isa = PBXBuildFile; fileRef = 835783C52B14A5C800E7D304 /* LoginData.json */; };
 		835A61902B067D61002F22A5 /* LOSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A618F2B067D61002F22A5 /* LOSlider.swift */; };
@@ -155,6 +156,7 @@
 		19C7AFCD2B02410F003B35F2 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		19C7AFD52B02584D003B35F2 /* KeychainStored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStored.swift; sourceTree = "<group>"; };
 		19E79ABF2B0A85D0009EA9ED /* LoopingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopingPlayerView.swift; sourceTree = "<group>"; };
+		834B7BD42B14F888002BD176 /* MockSignUpWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignUpWorker.swift; sourceTree = "<group>"; };
 		835783C22B14A41600E7D304 /* MockLoginWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginWorker.swift; sourceTree = "<group>"; };
 		835783C52B14A5C800E7D304 /* LoginData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LoginData.json; sourceTree = "<group>"; };
 		835783C72B14ADB600E7D304 /* Layover.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Layover.entitlements; sourceTree = "<group>"; };
@@ -394,7 +396,7 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
-        FC2511A72B04DA9C004717BC /* Map */ = {
+		FC2511A72B04DA9C004717BC /* Map */ = {
 			isa = PBXGroup;
 			children = (
 				FC767FA62B1269980088CF9B /* Views */,
@@ -443,8 +445,8 @@
 				835783C52B14A5C800E7D304 /* LoginData.json */,
 			);
 			path = MockData;
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		FC767FA62B1269980088CF9B /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -516,6 +518,7 @@
 				FC767F832B1214A70088CF9B /* MockUserWorker.swift */,
 				FC7E458F2AFF746E004F155A /* DummyWorker.swift */,
 				835783C22B14A41600E7D304 /* MockLoginWorker.swift */,
+				834B7BD42B14F888002BD176 /* MockSignUpWorker.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -765,6 +768,7 @@
 				FC4975992B03439000D8627F /* UIFont+.swift in Sources */,
 				FC767F952B1222350088CF9B /* ProfileImageDTO.swift in Sources */,
 				194551F52B037F2D00299768 /* LoginModels.swift in Sources */,
+				834B7BD52B14F888002BD176 /* MockSignUpWorker.swift in Sources */,
 				835A619E2B068115002F22A5 /* PlaybackWorker.swift in Sources */,
 				1972CCD22B125ED700C3C762 /* UserDefaultStored.swift in Sources */,
 				FC2511AD2B04EACD004717BC /* MapInteractor.swift in Sources */,

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/SignUpEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/SignUpEndPointFactory.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol SignUpEndPointFactory {
     func makeKakaoSignUpEndPoint(socialToken: String, username: String) -> EndPoint<Response<LoginDTO>>
+    func makeAppleSignUpEndPoint(identityToken: String, username: String) -> EndPoint<Response<LoginDTO>>
 }
 
 final class DefaultSignUpEndPointFactory: SignUpEndPointFactory {
@@ -23,5 +24,16 @@ final class DefaultSignUpEndPointFactory: SignUpEndPointFactory {
             method: .POST,
             bodyParameters: bodyParameters
         )
+    }
+
+    func makeAppleSignUpEndPoint(identityToken: String, username: String) -> EndPoint<Response<LoginDTO>> {
+        var bodyParameters: [String: String] = [:]
+        bodyParameters.updateValue(identityToken, forKey: "identityToken")
+        bodyParameters.updateValue(username, forKey: "username")
+
+        return EndPoint(
+            path: "/oauth/signup/apple",
+            method: .POST,
+            bodyParameters: bodyParameters)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -75,6 +75,7 @@ extension LoginInteractor: ASAuthorizationControllerDelegate {
             guard let identityToken: String = String(data: identityTokenData, encoding: .utf8) else {
                 return
             }
+            appleLoginToken = identityToken
             Task {
                 async let isRegistered: Bool = worker?.isRegisteredApple(with: identityToken) ?? false
                 async let loginResult: Bool = worker?.loginApple(with: identityToken) ?? false

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -49,7 +49,7 @@ final class LoginRouter: LoginRoutingLogic, LoginDataPassing {
         else { return }
 
         destination.signUpType = .apple
-        destination.identityToken = source.appleLoginToken
+        destination.socialToken = source.appleLoginToken
         viewController?.navigationController?.pushViewController(signUpViewController, animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -43,8 +43,13 @@ final class LoginRouter: LoginRoutingLogic, LoginDataPassing {
     }
 
     func navigateToAppleSignUp() {
-        // TODO: SignUpRouter로 토큰 값 전달 필요
         let signUpViewController = SignUpViewController()
+        guard let source = dataStore,
+              var destination = signUpViewController.router?.dataStore
+        else { return }
+
+        destination.signUpType = .apple
+        destination.identityToken = source.appleLoginToken
         viewController?.navigationController?.pushViewController(signUpViewController, animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpConfigurator.swift
@@ -17,7 +17,7 @@ final class SignUpConfigurator: Configurator {
         let viewController = viewController
         let interactor = SignUpInteractor()
         let userWorker = MockUserWorker()
-        let signUpWorker = SignUpWorker()
+        let signUpWorker = MockSignUpWorker()
         let presenter = SignUpPresenter()
         let router = SignUpRouter()
         viewController.interactor = interactor

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpInteractor.swift
@@ -17,7 +17,6 @@ protocol SignUpBusinessLogic {
 protocol SignUpDataStore: AnyObject {
     var signUpType: SignUpModels.SignUp.LoginType? { get set }
     var socialToken: String? { get set }
-    var identityToken: String? { get set }
 }
 
 final class SignUpInteractor: SignUpBusinessLogic, SignUpDataStore {
@@ -32,7 +31,6 @@ final class SignUpInteractor: SignUpBusinessLogic, SignUpDataStore {
 
     var signUpType: SignUpModels.SignUp.LoginType?
     var socialToken: String?
-    var identityToken: String?
 
     // MARK: - UseCase: 닉네임 유효성 검사
 
@@ -67,20 +65,18 @@ final class SignUpInteractor: SignUpBusinessLogic, SignUpDataStore {
     // MARK: - UseCase: SignUp
 
     func signUp(with request: SignUpModels.SignUp.Request) {
-        guard let signUpType else { return }
+        guard let signUpType, let socialToken else { return }
 
         Task {
             switch signUpType {
             case .kakao:
-                guard let socialToken else { return }
                 if await signUpWorker?.signUp(withKakao: socialToken, username: request.nickname) == true {
                     await MainActor.run {
                         presenter?.presentSignUpSuccess()
                     }
                 }
             case .apple:
-                guard let identityToken else { return }
-                if await signUpWorker?.signUp(withApple: identityToken, username: request.nickname) == true {
+                if await signUpWorker?.signUp(withApple: socialToken, username: request.nickname) == true {
                     await MainActor.run {
                         presenter?.presentSignUpSuccess()
                     }

--- a/iOS/Layover/Layover/Workers/MockLoginWorker.swift
+++ b/iOS/Layover/Layover/Workers/MockLoginWorker.swift
@@ -45,7 +45,7 @@ final class MockLoginWorker: LoginWorkerProtocol {
 
     func isRegisteredApple(with identityToken: String) async -> Bool {
         // TODO: 로직 구현
-        return true
+        return false
     }
 
     func loginApple(with identityToken: String) async -> Bool {

--- a/iOS/Layover/Layover/Workers/MockSignUpWorker.swift
+++ b/iOS/Layover/Layover/Workers/MockSignUpWorker.swift
@@ -1,0 +1,63 @@
+//
+//  MockSignUpWorker.swift
+//  Layover
+//
+//  Created by 황지웅 on 11/28/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+import OSLog
+
+final class MockSignUpWorker {
+
+    // MARK: - Properties
+
+    private let signUpEndPointFactory: SignUpEndPointFactory
+    private let provider: ProviderType
+    private let authManager: AuthManager
+
+    // MARK: - Initializer
+
+    init(signUpEndPointFactory: SignUpEndPointFactory = DefaultSignUpEndPointFactory(), provider: ProviderType = Provider(session: .initMockSession()), authManager: AuthManager = .shared) {
+        self.signUpEndPointFactory = signUpEndPointFactory
+        self.provider = provider
+        self.authManager = authManager
+    }
+}
+
+// MARK: - SignUpWorkerProtocol
+
+extension MockSignUpWorker: SignUpWorkerProtocol {
+    func signUp(withKakao socialToken: String, username: String) async -> Bool {
+        // TODO: 로직 구현
+        return true
+    }
+
+    func signUp(withApple identityToken: String, username: String) async -> Bool {
+        guard let fileLocation: URL = Bundle.main.url(forResource: "LoginData", withExtension: "json") else {
+            return false
+        }
+        guard let mockData: Data = try? Data(contentsOf: fileLocation) else {
+            return false
+        }
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)
+            return (response, mockData, nil)
+        }
+        do {
+            let endPoint: EndPoint = signUpEndPointFactory.makeAppleSignUpEndPoint(identityToken: identityToken, username: username)
+            let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            print(response.data?.accessToken ?? "")
+            print(response.data?.refreshToken ?? "")
+            return true
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return false
+        }
+    }
+
+}


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
 - [x] 회원가입 로직 구현
 - [x] Mock데이터 구현
 
#### 📌 변경 사항
SignUp Worker가 Mock으로 들어가있습니다. 이 부분 확인하시고 작업하시길 바랍니다.
SignUpViewController에 token을 전달하는 과정에서
```swift
 guard let source = dataStore,
        var destination = signUpViewController.router?.dataStore
  else { return }

  destination.signUpType = .apple
  destination.identityToken = source.appleLoginToken
``` 
이러한 방식을 써봤는데 어떠신지요. 의견을 들려주세요. inout쓰는 것 보단 이렇게 넘겨 주는게 괜찮은 방식이라고 생각해서요.
제가 call by reference 껌벅 죽는 편인데 Swift는 inout을 좀 피하는 분위기인 것 같더군요?
##### 📸 ScreenShot

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/ec89de7a-6c76-41cb-a41d-385c90522fff

#### Linked Issue
close #121 
