### PR TITLE
feat: 홈 뷰 캐러셀 나머지 UI 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -394,7 +394,7 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
-        FC2511A72B04DA9C004717BC /* Map */ = {
+		FC2511A72B04DA9C004717BC /* Map */ = {
 			isa = PBXGroup;
 			children = (
 				FC767FA62B1269980088CF9B /* Views */,
@@ -443,8 +443,8 @@
 				835783C52B14A5C800E7D304 /* LoginData.json */,
 			);
 			path = MockData;
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		FC767FA62B1269980088CF9B /* Views */ = {
 			isa = PBXGroup;
 			children = (

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -14,6 +14,21 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     private let loopingPlayerView = LoopingPlayerView()
 
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = UIFont.loFont(type: .subtitle)
+        return label
+    }()
+
+    private let tagStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 4
+        stackView.alignment = .center
+        return stackView
+    }()
+
     // MARK: - Properties
 
     var isPlayingVideos: Bool {
@@ -43,14 +58,22 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     }
 
     private func setConstraints() {
-        contentView.addSubviews(loopingPlayerView)
-        [loopingPlayerView].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        contentView.addSubviews(loopingPlayerView, titleLabel, tagStackView)
+        contentView.subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
 
         NSLayoutConstraint.activate([
             loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
             loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            tagStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -23),
+            tagStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25),
+            tagStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -25),
+            tagStackView.heightAnchor.constraint(equalToConstant: 25),
+
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25),
+            titleLabel.bottomAnchor.constraint(equalTo: tagStackView.topAnchor, constant: -18)
         ])
     }
 
@@ -60,6 +83,31 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
         loopingPlayerView.disable()
         loopingPlayerView.prepareVideo(with: url, loopStart: time, duration: 3.0)
         loopingPlayerView.player?.isMuted = true
+    }
+
+    func configure(title: String, tags: [String]) {
+        titleLabel.text = title
+        setTagButtons(with: tags)
+    }
+
+    private func setTagButtons(with tags: [String]) {
+        tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        tags.forEach {
+            var configuration = UIButton.Configuration.filled()
+            configuration.baseBackgroundColor = UIColor.primaryPurple
+            configuration.title = $0
+            configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.loFont(ofSize: 13, weight: .bold)
+                outgoing.foregroundColor = UIColor.white
+                return outgoing
+            }
+            let button = UIButton(configuration: configuration)
+            button.clipsToBounds = true
+            button.layer.cornerRadius = 12
+            tagStackView.addArrangedSubview(button)
+        }
+        tagStackView.addArrangedSubview(UIView())
     }
 
     func playVideo() {

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .white
+        label.textColor = .layoverWhite
         label.font = UIFont.loFont(type: .subtitle)
         return label
     }()
@@ -99,7 +99,7 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
             configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
                 var outgoing = incoming
                 outgoing.font = UIFont.loFont(ofSize: 13, weight: .bold)
-                outgoing.foregroundColor = UIColor.white
+                outgoing.foregroundColor = UIColor.layoverWhite
                 return outgoing
             }
             let button = UIButton(configuration: configuration)

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -31,7 +31,10 @@ extension HomeInteractor: HomeBusinessLogic {
     func fetchVideos(with request: Models.CarouselVideos.Request) {
         let response = Models.CarouselVideos.Response(videoURLs: [
             URL(string: "https://assets.afcdn.com/video49/20210722/v_645516.m3u8")!,
-            URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!
+            URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!,
+            URL(string: "https://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8")!,
+            URL(string: "https://playertest.longtailvideo.com/adaptive/wowzaid3/playlist.m3u8")!,
+            URL(string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8")!
         ])
         presenter?.presentVideoURL(with: response)
     }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -41,7 +41,7 @@ final class HomeViewController: BaseViewController {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? HomeCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.setVideo(url: url, loopingAt: .zero)
-
+        cell.configure(title: "요리왕 비룡 데뷔", tags: ["#천상의맛", "#갈갈갈", "#빨리주세요"])
         return cell
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.
> [!NOTE] 
> 홈 뷰 캐러셀의 제목 라벨, 태그뷰를 구현했습니다.

- 태그 뷰는 UIButton과 UIStackView로 구현했고, 마지막에 Spacer 역할을 하는 빈 UIView()를 넣는 방식으로 설정했습니다.

##### 📸 ScreenShot
<img src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/a2fb4776-8d4d-4877-9623-744d3240e111" width=40%>

#### Linked Issue
close #125 
