### PR TITLE
chore: swagger 정리, 회원가입 세부 로직 추가

### DIFF
--- a/BE/layover/src/member/dtos/member-infos-res.dto.ts
+++ b/BE/layover/src/member/dtos/member-infos-res.dto.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class MemberInfosResDto {
   @ApiProperty({
+    example: 221,
+    description: '각 멤버를 유일하게 구분하는 id 값',
+  })
+  id: number;
+
+  @ApiProperty({
     example: 'hwani',
     description: '요청한 회원의 닉네임',
   })
@@ -19,7 +25,8 @@ export class MemberInfosResDto {
   })
   profile_image_url: string;
 
-  constructor(username: string, introduce: string, profile_image_url: string) {
+  constructor(id: number, username: string, introduce: string, profile_image_url: string) {
+    this.id = id;
     this.username = username;
     this.introduce = introduce;
     this.profile_image_url = profile_image_url;

--- a/BE/layover/src/member/member.controller.ts
+++ b/BE/layover/src/member/member.controller.ts
@@ -186,12 +186,12 @@ export class MemberController {
   }
 
   @ApiOperation({
-    summary: '회원 정보 요청',
-    description: '회원 정보들(닉네임, 자기소개, 프로필 이미지 url)을 응답으로 줍니다.',
+    summary: '회원(본인) 정보 요청',
+    description: '회원(본인) 정보들(닉네임, 자기소개, 프로필 이미지 url)을 응답으로 줍니다.',
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: '회원 정보들',
+    description: '회원(본인) 정보들',
     schema: {
       type: 'object',
       properties: {
@@ -222,6 +222,6 @@ export class MemberController {
     }
 
     // 응답
-    throw new CustomResponse(ECustomCode.SUCCESS, new MemberInfosResDto(username, introduce, preSignedUrl));
+    throw new CustomResponse(ECustomCode.SUCCESS, new MemberInfosResDto(id, username, introduce, preSignedUrl));
   }
 }

--- a/BE/layover/src/member/member.controller.ts
+++ b/BE/layover/src/member/member.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, HttpStatus, Patch, Post } from '@nestjs/common';
 import { CheckUsernameDto } from './dtos/check-username.dto';
 import { MemberService } from './member.service';
-import { ApiOperation, ApiResponse, ApiTags, getSchemaPath } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags, getSchemaPath } from '@nestjs/swagger';
 import { CheckUsernameResDto } from './dtos/check-username-res.dto';
 import { CustomResponse } from 'src/response/custom-response';
 import { ECustomCode } from 'src/response/ecustom-code.jenum';
@@ -15,44 +15,13 @@ import { DeleteMemberResDto } from './dtos/delete-member-res.dto';
 import { ProfilePresignedUrlDto } from './dtos/profile-presigned-url.dto';
 import { ProfilePresignedUrlResDto } from './dtos/profile-presigned-url-res.dto';
 import { MemberInfosResDto } from './dtos/member-infos-res.dto';
+import { SWAGGER } from 'src/utils/swaggerUtils';
 
 @ApiTags('Member API')
 @Controller('member')
-@ApiResponse({
-  status: HttpStatus.BAD_REQUEST,
-  description: 'client의 요청이 잘못된 경우',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'OAUTH__' },
-      message: { type: 'string', example: '응답코드에 맞는 메시지' },
-      statusCode: { type: 'number', example: HttpStatus.BAD_REQUEST },
-    },
-  },
-})
-@ApiResponse({
-  description: '예상치 못한 Http Exception',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
-      message: { type: 'string', example: 'message from nest' },
-      statusCode: { type: 'number', example: HttpStatus.NOT_FOUND },
-    },
-  },
-})
-@ApiResponse({
-  status: HttpStatus.INTERNAL_SERVER_ERROR,
-  description: '예상치 못한 서버 Exception',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
-      message: { type: 'string', example: 'message from nest' },
-      statusCode: { type: 'number', example: HttpStatus.INTERNAL_SERVER_ERROR },
-    },
-  },
-})
+@ApiResponse(SWAGGER.BAD_REQUEST_RESPONSE)
+@ApiResponse(SWAGGER.HTTP_ERROR_RESPONSE)
+@ApiResponse(SWAGGER.INTERNAL_SERVER_ERROR_RESPONSE)
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 
@@ -70,18 +39,6 @@ export class MemberController {
         message: { type: 'boolean', example: '성공' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(CheckUsernameResDto) },
-      },
-    },
-  })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '리프레시 토큰 유효기간 만료',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'JWT02' },
-        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
       },
     },
   })
@@ -108,6 +65,8 @@ export class MemberController {
       },
     },
   })
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Patch('username')
   async updateUsername(@CustomHeader(new JwtValidationPipe()) payload, @Body() usernameDto: UsernameDto) {
     const id = payload.memberId;
@@ -141,18 +100,8 @@ export class MemberController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '리프레시 토큰 유효기간 만료',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'JWT02' },
-        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Patch('introduce')
   async updateIntroduce(@CustomHeader(new JwtValidationPipe()) payload, @Body() introduceDto: IntroduceDto) {
     const id = payload.memberId;
@@ -182,6 +131,8 @@ export class MemberController {
       },
     },
   })
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Delete()
   async deleteMember(@CustomHeader(new JwtValidationPipe()) payload) {
     const id = payload.memberId;
@@ -213,18 +164,8 @@ export class MemberController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '리프레시 토큰 유효기간 만료',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'JWT02' },
-        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Post('profile-image/presigned-url')
   async getUploadProfilePresignedUrl(@CustomHeader(new JwtValidationPipe()) payload, @Body() body: ProfilePresignedUrlDto) {
     const id = payload.memberId;
@@ -261,18 +202,8 @@ export class MemberController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '리프레시 토큰 유효기간 만료',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'JWT02' },
-        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Get()
   async getMemberInfos(@CustomHeader(new JwtValidationPipe()) payload) {
     const id = payload.memberId;

--- a/BE/layover/src/member/member.controller.ts
+++ b/BE/layover/src/member/member.controller.ts
@@ -19,7 +19,7 @@ import { SWAGGER } from 'src/utils/swaggerUtils';
 
 @ApiTags('Member API')
 @Controller('member')
-@ApiResponse(SWAGGER.BAD_REQUEST_RESPONSE)
+@ApiResponse(SWAGGER.SERVER_CUSTOM_RESPONSE)
 @ApiResponse(SWAGGER.HTTP_ERROR_RESPONSE)
 @ApiResponse(SWAGGER.INTERNAL_SERVER_ERROR_RESPONSE)
 export class MemberController {

--- a/BE/layover/src/member/member.service.ts
+++ b/BE/layover/src/member/member.service.ts
@@ -57,6 +57,10 @@ export class MemberService {
     return await this.memberRepository.findOne({ where: { id } });
   }
 
+  async findMemberByHash(memberHash: string): Promise<Member> {
+    return await this.memberRepository.findOne({ where: { hash: memberHash } });
+  }
+
   makeUploadPreSignedUrl(bucketname: string, filename: string, fileCategory: string, filetype: string): { preSignedUrl: string } {
     return makeUploadPreSignedUrl(bucketname, filename, fileCategory, filetype);
   }

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -15,7 +15,7 @@ import { SWAGGER } from 'src/utils/swaggerUtils';
 
 @ApiTags('OAuth API')
 @Controller('oauth')
-@ApiResponse(SWAGGER.BAD_REQUEST_RESPONSE)
+@ApiResponse(SWAGGER.SERVER_CUSTOM_RESPONSE)
 @ApiResponse(SWAGGER.HTTP_ERROR_RESPONSE)
 @ApiResponse(SWAGGER.INTERNAL_SERVER_ERROR_RESPONSE)
 export class OauthController {

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -4,51 +4,20 @@ import { OauthService } from './oauth.service';
 import { JwtValidationPipe } from 'src/pipes/jwt.validation.pipe';
 import { CustomResponse } from '../response/custom-response';
 import { ECustomCode } from '../response/ecustom-code.jenum';
-import { ApiOperation, ApiResponse, ApiTags, getSchemaPath } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags, getSchemaPath } from '@nestjs/swagger';
 import { KakaoLoginDto } from './dtos/kakao-login.dto';
 import { AppleLoginDto } from './dtos/apple-login.dto';
 import { KakaoSignupDto } from './dtos/kakao-signup.dto';
 import { AppleSignupDto } from './dtos/apple-signup.dto';
 import { TokenResDto } from './dtos/token-res.dto';
 import { CustomHeader } from 'src/pipes/custom-header.decorator';
+import { SWAGGER } from 'src/utils/swaggerUtils';
 
 @ApiTags('OAuth API')
 @Controller('oauth')
-@ApiResponse({
-  status: HttpStatus.BAD_REQUEST,
-  description: 'Client의 요청이 잘못된 경우',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'OAUTH__' },
-      message: { type: 'string', example: '응답코드에 맞는 메시지' },
-      statusCode: { type: 'number', example: HttpStatus.BAD_REQUEST },
-    },
-  },
-})
-@ApiResponse({
-  description: '예상치 못한 Http Exception',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
-      message: { type: 'string', example: 'message from nest' },
-      statusCode: { type: 'number', example: HttpStatus.NOT_FOUND },
-    },
-  },
-})
-@ApiResponse({
-  status: HttpStatus.INTERNAL_SERVER_ERROR,
-  description: '예상치 못한 서버 Exception',
-  schema: {
-    type: 'object',
-    properties: {
-      customCode: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
-      message: { type: 'string', example: 'message from nest' },
-      statusCode: { type: 'number', example: HttpStatus.INTERNAL_SERVER_ERROR },
-    },
-  },
-})
+@ApiResponse(SWAGGER.BAD_REQUEST_RESPONSE)
+@ApiResponse(SWAGGER.HTTP_ERROR_RESPONSE)
+@ApiResponse(SWAGGER.INTERNAL_SERVER_ERROR_RESPONSE)
 export class OauthController {
   constructor(private readonly oauthService: OauthService) {}
 
@@ -69,18 +38,7 @@ export class OauthController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '회원가입 되지 않은 유저',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'OAUTH01' },
-        message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.NOT_OUR_MEMBER_RESPONSE)
   @Post('kakao')
   async processKakaoLogin(@Body() kakaoLoginDto: KakaoLoginDto) {
     // memberHash 구하기
@@ -110,18 +68,7 @@ export class OauthController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '회원가입 되지 않은 유저',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'OAUTH01' },
-        message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.NOT_OUR_MEMBER_RESPONSE)
   @Post('apple')
   async processAppleLogin(@Body() appleLoginDto: AppleLoginDto) {
     // memberHash 구하기
@@ -151,18 +98,7 @@ export class OauthController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '회원가입 되지 않은 유저',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'OAUTH01' },
-        message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.NOT_OUR_MEMBER_RESPONSE)
   @Post('signup/kakao')
   async processKakaoSignup(@Body() kakaoSignupDto: KakaoSignupDto) {
     const [accessToken, username] = [kakaoSignupDto.accessToken, kakaoSignupDto.username];
@@ -202,18 +138,7 @@ export class OauthController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '회원가입 되지 않은 유저',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'OAUTH01' },
-        message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.NOT_OUR_MEMBER_RESPONSE)
   @Post('signup/apple')
   async processAppleSignup(@Body() appleSignupDto: AppleSignupDto) {
     const [identityToken, username] = [appleSignupDto.identityToken, appleSignupDto.username];
@@ -253,18 +178,8 @@ export class OauthController {
       },
     },
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: '리프레시 토큰 유효기간 만료',
-    schema: {
-      type: 'object',
-      properties: {
-        customCode: { type: 'string', example: 'JWT02' },
-        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
-        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
-      },
-    },
-  })
+  @ApiResponse(SWAGGER.REFRESH_TOKEN_TIMEOUT_RESPONSE)
+  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
   @Post('refresh-token')
   async renewTokens(@CustomHeader(new JwtValidationPipe()) payload) {
     // 새로운 토큰을 생성하고 이를 반환함

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -106,6 +106,14 @@ export class OauthController {
     // memberHash 구하기
     const memberHash = await this.oauthService.getKakaoMemberHash(accessToken);
 
+    // 이미 회원가입 돼있다면, 바로 로그인 시키기
+    const isUserExist = await this.oauthService.isMemberExistByHash(memberHash);
+    if (isUserExist) {
+      // Response access token and refresh token
+      const tokenResponseDto = await this.oauthService.generateAccessRefreshTokens(memberHash);
+      throw new CustomResponse(ECustomCode.SUCCESS, tokenResponseDto);
+    }
+
     // 닉네임 중복 확인 : MEMBER01
     if (await this.oauthService.isExistUsername(username)) {
       throw new CustomResponse(ECustomCode.MEMBER01);
@@ -114,10 +122,8 @@ export class OauthController {
     // signup
     await this.oauthService.signup(memberHash, username, 'kakao');
 
-    // token들 발급
+    // Response access token and refresh token
     const tokenResponseDto = await this.oauthService.generateAccessRefreshTokens(memberHash);
-
-    // return access token and refresh token
     throw new CustomResponse(ECustomCode.SUCCESS, tokenResponseDto);
   }
 
@@ -146,6 +152,14 @@ export class OauthController {
     // memberHash 구하기
     const memberHash = this.oauthService.getAppleMemberHash(identityToken);
 
+    // 이미 회원가입 돼있다면, 바로 로그인 시키기
+    const isUserExist = await this.oauthService.isMemberExistByHash(memberHash);
+    if (isUserExist) {
+      // Response access token and refresh token
+      const tokenResponseDto = await this.oauthService.generateAccessRefreshTokens(memberHash);
+      throw new CustomResponse(ECustomCode.SUCCESS, tokenResponseDto);
+    }
+
     // 닉네임 중복 확인 : MEMBER01
     if (await this.oauthService.isExistUsername(username)) {
       throw new CustomResponse(ECustomCode.MEMBER01);
@@ -154,10 +168,8 @@ export class OauthController {
     // signup
     await this.oauthService.signup(memberHash, username, 'apple');
 
-    // token들 발급
+    // Response access token and refresh token
     const tokenResponseDto = await this.oauthService.generateAccessRefreshTokens(memberHash);
-
-    // return access token and refresh token
     throw new CustomResponse(ECustomCode.SUCCESS, tokenResponseDto);
   }
 

--- a/BE/layover/src/oauth/oauth.service.ts
+++ b/BE/layover/src/oauth/oauth.service.ts
@@ -90,7 +90,8 @@ export class OauthService {
 
   async generateAccessRefreshTokens(memberHash: string): Promise<TokenResDto> {
     // memberHash로부터 해당 회원이 저장된 db pk를 찾아옴.
-    const memberId = 777;
+    const member = await this.memberService.findMemberByHash(memberHash);
+    const memberId = member.id;
 
     // access, refresh token 생성
     const accessTokenPaylaod = makeJwtPaylaod('access', memberHash, memberId);

--- a/BE/layover/src/utils/jwtUtils.ts
+++ b/BE/layover/src/utils/jwtUtils.ts
@@ -1,18 +1,19 @@
 import { ACCESS_TOKEN_EXP_IN_SECOND, REFRESH_TOKEN_EXP_IN_SECOND } from 'src/config';
 import { CustomResponse } from 'src/response/custom-response';
 import { ECustomCode } from '../response/ecustom-code.jenum';
+import { v4 } from 'uuid';
 
 type tokenType = 'access' | 'refresh';
 
 export function makeJwtPaylaod(token: tokenType, memberHash: string, memberId: number): any {
   const issuedNumericDate = Math.floor(Date.now() / 1000); // 현재 시점을 numericDate 형식으로 저장, Date.now()는 밀리세컨드 단위라 세컨드 단위로 나타내기 위해 1000으로 나눔.
   const expirationPeriod = token === 'access' ? ACCESS_TOKEN_EXP_IN_SECOND : REFRESH_TOKEN_EXP_IN_SECOND;
-  const uuid = 1234;
+  const uuid = v4();
 
   return {
     iss: `${process.env.LAYOVER_PUBLIC_IP}`,
     exp: issuedNumericDate + expirationPeriod,
-    sub: `Layover${token}Token`,
+    sub: `${memberHash}`,
     aud: `${process.env.LAYOVER_PUBLIC_IP}`,
     nbf: issuedNumericDate,
     iat: issuedNumericDate,

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -2,7 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 
 export const SWAGGER = {
   BAD_REQUEST_RESPONSE: {
-    status: '000',
+    status: 0,
     description: 'Client의 요청이 잘못된 경우',
     schema: {
       type: 'object',
@@ -15,7 +15,7 @@ export const SWAGGER = {
   },
 
   HTTP_ERROR_RESPONSE: {
-    status: '000',
+    status: 0,
     description: '예상치 못한 Http Exception',
     schema: {
       type: 'object',

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -1,9 +1,9 @@
 import { HttpStatus } from '@nestjs/common';
 
 export const SWAGGER = {
-  BAD_REQUEST_RESPONSE: {
+  SERVER_CUSTOM_RESPONSE: {
     status: 0,
-    description: 'Client의 요청이 잘못된 경우',
+    description: '서버에서 처리한 예외',
     schema: {
       type: 'object',
       properties: {

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -1,0 +1,94 @@
+import { HttpStatus } from '@nestjs/common';
+
+export const SWAGGER = {
+  BAD_REQUEST_RESPONSE: {
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Client의 요청이 잘못된 경우',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'OAUTH__' },
+        message: { type: 'string', example: '응답코드에 맞는 메시지' },
+        statusCode: { type: 'number', example: HttpStatus.BAD_REQUEST },
+      },
+    },
+  },
+
+  HTTP_ERROR_RESPONSE: {
+    status: HttpStatus.NOT_FOUND,
+    description: '예상치 못한 Http Exception',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
+        message: { type: 'string', example: 'message from nest' },
+        statusCode: { type: 'number', example: HttpStatus.NOT_FOUND },
+      },
+    },
+  },
+
+  INTERNAL_SERVER_ERROR_RESPONSE: {
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: '예상치 못한 서버 Exception',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
+        message: { type: 'string', example: 'message from nest' },
+        statusCode: { type: 'number', example: HttpStatus.INTERNAL_SERVER_ERROR },
+      },
+    },
+  },
+
+  NOT_OUR_MEMBER_RESPONSE: {
+    status: HttpStatus.UNAUTHORIZED,
+    description: '회원가입 되지 않은 유저',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'OAUTH01' },
+        message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
+        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
+      },
+    },
+  },
+
+  REFRESH_TOKEN_TIMEOUT_RESPONSE: {
+    status: HttpStatus.UNAUTHORIZED,
+    description: '리프레시 토큰 유효기간 만료',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'JWT02' },
+        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
+        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
+      },
+    },
+  },
+
+  ACCESS_TOKEN_TIMEOUT_RESPONSE: {
+    status: HttpStatus.UNAUTHORIZED,
+    description: '엑세스 토큰 유효기간 만료',
+    schema: {
+      type: 'object',
+      properties: {
+        customCode: { type: 'string', example: 'JWT02' },
+        message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
+        statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
+      },
+    },
+  },
+
+  AUTHORIZATION_HEADER: {
+    name: 'Authorization',
+    description: 'Bearer {token}',
+  },
+};
+/*
+@ApiHeaders([
+  {
+    name: 'Authorization',
+    description: 'Bearer {token}',
+  },
+])
+*/

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -2,27 +2,27 @@ import { HttpStatus } from '@nestjs/common';
 
 export const SWAGGER = {
   BAD_REQUEST_RESPONSE: {
-    status: HttpStatus.BAD_REQUEST,
+    status: '000',
     description: 'Client의 요청이 잘못된 경우',
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'OAUTH__' },
-        message: { type: 'string', example: '응답코드에 맞는 메시지' },
-        statusCode: { type: 'number', example: HttpStatus.BAD_REQUEST },
+        customCode: { type: 'string', example: '<type><num>' },
+        message: { type: 'string', example: '서버에서 처리한 예외' },
+        statusCode: { type: 'number', example: '000' },
       },
     },
   },
 
   HTTP_ERROR_RESPONSE: {
-    status: HttpStatus.NOT_FOUND,
+    status: '000',
     description: '예상치 못한 Http Exception',
     schema: {
       type: 'object',
       properties: {
         customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
         message: { type: 'string', example: 'message from nest' },
-        statusCode: { type: 'number', example: HttpStatus.NOT_FOUND },
+        statusCode: { type: 'number', example: '000' },
       },
     },
   },


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- swagger 코드를 간단하게 만들기 위해 상수화
- 회원가입 요청 때 이미 회원가입 된 유저라면 바로 로그인 되도록 처리함.
- jwt 토큰 각 필드에 공식문서에 작성된 의미에 맞는 값이 들어가도록 함

#### 📌 변경 사항
없습니다.

#### Linked Issue
close #137 
