### PR TITLE
bug: navigationBar 중첩 버그 수정

### DIFF
--- a/iOS/Layover/Layover/SceneDelegate.swift
+++ b/iOS/Layover/Layover/SceneDelegate.swift
@@ -80,6 +80,7 @@ extension SceneDelegate {
     @objc private func routeToLoginViewController() {
         guard let rootNavigationViewController = window?.rootViewController as? UINavigationController else { return }
         // TODO: 세션이 만료되었습니다. Toast 띄우기
+        rootNavigationViewController.setNavigationBarHidden(false, animated: false)
         rootNavigationViewController.setViewControllers([LoginViewController()], animated: true)
     }
 }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -118,10 +118,12 @@ final class EditProfileViewController: BaseViewController {
     // MARK: - Methods
 
     override func setUI() {
+        super.setUI()
         self.title = "프로필 수정"
     }
 
     override func setConstraints() {
+        super.setConstraints()
         view.addSubviews(profileImageView, editProfileImageButton, nicknameTextfield, nicknameAlertLabel, introduceTextfield,
                          introduceAlertLabel, nicknameAlertLabel, checkDuplicateNicknameButton, confirmButton)
         view.subviews.forEach {

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileRouter.swift
@@ -35,7 +35,7 @@ class ProfileRouter: NSObject, ProfileRoutingLogic, ProfileDataPassing {
         destination.nickname = source.nickname
         destination.introduce = source.introduce
         destination.profileImage = source.profileImage
-
+        editProfileViewController.hidesBottomBarWhenPushed = true
         viewController?.navigationController?.pushViewController(editProfileViewController, animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpRouter.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpRouter.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 CodeBomber. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 protocol SignUpRoutingLogic {
     func routeToBack()
@@ -33,6 +33,7 @@ final class SignUpRouter: SignUpRoutingLogic, SignUpDataPassing {
 
     func navigateToMain() {
         let mainTabBarViewController = MainTabBarViewController()
+        viewController?.navigationController?.setNavigationBarHidden(true, animated: false)
         viewController?.navigationController?.setViewControllers([mainTabBarViewController], animated: true)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
@@ -31,7 +31,7 @@ final class MainTabBarConfigurator: Configurator {
         profileViewController.tabBarItem = UITabBarItem(title: "프로필",
                                                         image: profileIconImage.withTintColor(.white),
                                                         selectedImage: nil)
-
+        viewController.navigationController?.setNavigationBarHidden(true, animated: false)
         viewController.setViewControllers([
             homeViewController,
             mapViewController,


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.
- 뷰컨트롤러 푸시 할 경우, navigationBar 중첩되던 버그 수정
- 프로필 수정 뷰 진입 시 backgroundColor 투명으로 보이던 버그 수정

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

> [!WARNING]
> BaseViewController setUI() 메서드 오버라이드 시, 부모 메서드 호출
- 베이스 뷰컨의 setUI 메서드 오버라이드 해서 사용할 경우, 부모 메서드를 반드시 호출해 주어야 backgroundColor 설정이 적용됩니다.

> [!WARNING]
> navigationController navigationBar 중첩

- 중첩된 원인은 현재 라우팅 시나리오가 루트 뷰컨(네비게이션 컨트롤러) -> 메인 탭바 -> 각 탭별 네비게이션 컨트롤러
로 되어있기 때문에 메인 탭바로 진입 시에는 루트 네비게이션 컨트롤러의 네비바를 hide 설정해야합니다.
  - 대신 로그인 뷰로 갈 경우는 다시 보이도록!
- 우리 앱은 Code Base UI 이기 떄문에, 나중에 스플래시 구현할 때도 주의해서 작업 해야겠네요.

#### Linked Issue
close #142
