### PR TITLE
 feat: 재생화면 VIP 싸이클 적용

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1901D4A22B18F4BE00617A64 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D4A12B18F4BE00617A64 /* System.swift */; };
 		193686722B15BCA7008902CD /* UserEndPointFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193686712B15BCA7008902CD /* UserEndPointFactory.swift */; };
 		193686742B15C489008902CD /* UserWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193686732B15C489008902CD /* UserWorker.swift */; };
 		194551F22B037F2D00299768 /* LoginPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194551EC2B037F2D00299768 /* LoginPresenter.swift */; };
@@ -160,6 +161,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1901D4A12B18F4BE00617A64 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		193686712B15BCA7008902CD /* UserEndPointFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEndPointFactory.swift; sourceTree = "<group>"; };
 		193686732B15C489008902CD /* UserWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWorker.swift; sourceTree = "<group>"; };
 		194551EC2B037F2D00299768 /* LoginPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPresenter.swift; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 			children = (
 				1972CCD02B125E8800C3C762 /* UserDefaults */,
 				19C7AFD42B02583C003B35F2 /* Keychain */,
+				1901D4A12B18F4BE00617A64 /* System.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -974,6 +977,7 @@
 				19A169242B176C5F00DB34C0 /* TagPlayListWorker.swift in Sources */,
 				FCE52FF82B0FCAF7002CDB75 /* MockURLProtocol.swift in Sources */,
 				FC930E792B0CD75C00AA48E3 /* ProfileViewController.swift in Sources */,
+				1901D4A22B18F4BE00617A64 /* System.swift in Sources */,
 				FC7E453A2AFEB623004F155A /* AppDelegate.swift in Sources */,
 				1972CCD82B13A2EC00C3C762 /* SignUpEndPointFactory.swift in Sources */,
 				19A169262B176C5F00DB34C0 /* TagPlayListModels.swift in Sources */,

--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -88,7 +88,15 @@
 		FC2511AD2B04EACD004717BC /* MapInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511AC2B04EACD004717BC /* MapInteractor.swift */; };
 		FC2511AF2B04EAD9004717BC /* MapPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511AE2B04EAD9004717BC /* MapPresenter.swift */; };
 		FC2511B12B04EAEC004717BC /* MapModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2511B02B04EAEC004717BC /* MapModels.swift */; };
+		FC3752302B170A620000D439 /* EditVideoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522A2B170A620000D439 /* EditVideoPresenter.swift */; };
+		FC3752312B170A620000D439 /* EditVideoWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522B2B170A620000D439 /* EditVideoWorker.swift */; };
+		FC3752322B170A620000D439 /* EditVideoRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522C2B170A620000D439 /* EditVideoRouter.swift */; };
+		FC3752332B170A620000D439 /* EditVideoModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522D2B170A620000D439 /* EditVideoModels.swift */; };
+		FC3752342B170A620000D439 /* EditVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522E2B170A620000D439 /* EditVideoViewController.swift */; };
+		FC3752352B170A620000D439 /* EditVideoInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC37522F2B170A620000D439 /* EditVideoInteractor.swift */; };
+		FC3752372B170B230000D439 /* EditVideoConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3752362B170B230000D439 /* EditVideoConfigurator.swift */; };
 		FC3F3BD82B069EB30080E3A6 /* MapCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3F3BD72B069EB30080E3A6 /* MapCarouselCollectionViewCell.swift */; };
+		FC42E4142B17AB69005D4956 /* VideoFileWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC42E4132B17AB69005D4956 /* VideoFileWorker.swift */; };
 		FC49758F2B03432800D8627F /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FC4975862B03432700D8627F /* Pretendard-SemiBold.ttf */; };
 		FC4975932B03432800D8627F /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FC49758A2B03432800D8627F /* Pretendard-Bold.ttf */; };
 		FC4975942B03432800D8627F /* Pretendard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FC49758B2B03432800D8627F /* Pretendard-Regular.ttf */; };
@@ -235,7 +243,15 @@
 		FC2511AC2B04EACD004717BC /* MapInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapInteractor.swift; sourceTree = "<group>"; };
 		FC2511AE2B04EAD9004717BC /* MapPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPresenter.swift; sourceTree = "<group>"; };
 		FC2511B02B04EAEC004717BC /* MapModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModels.swift; sourceTree = "<group>"; };
+		FC37522A2B170A620000D439 /* EditVideoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoPresenter.swift; sourceTree = "<group>"; };
+		FC37522B2B170A620000D439 /* EditVideoWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoWorker.swift; sourceTree = "<group>"; };
+		FC37522C2B170A620000D439 /* EditVideoRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoRouter.swift; sourceTree = "<group>"; };
+		FC37522D2B170A620000D439 /* EditVideoModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoModels.swift; sourceTree = "<group>"; };
+		FC37522E2B170A620000D439 /* EditVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoViewController.swift; sourceTree = "<group>"; };
+		FC37522F2B170A620000D439 /* EditVideoInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoInteractor.swift; sourceTree = "<group>"; };
+		FC3752362B170B230000D439 /* EditVideoConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditVideoConfigurator.swift; sourceTree = "<group>"; };
 		FC3F3BD72B069EB30080E3A6 /* MapCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
+		FC42E4132B17AB69005D4956 /* VideoFileWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFileWorker.swift; sourceTree = "<group>"; };
 		FC4975862B03432700D8627F /* Pretendard-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.ttf"; sourceTree = "<group>"; };
 		FC49758A2B03432800D8627F /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		FC49758B2B03432800D8627F /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.ttf"; sourceTree = "<group>"; };
@@ -519,6 +535,20 @@
 			path = Map;
 			sourceTree = "<group>";
 		};
+		FC3752292B170A050000D439 /* EditVideo */ = {
+			isa = PBXGroup;
+			children = (
+				FC37522E2B170A620000D439 /* EditVideoViewController.swift */,
+				FC37522F2B170A620000D439 /* EditVideoInteractor.swift */,
+				FC37522A2B170A620000D439 /* EditVideoPresenter.swift */,
+				FC37522D2B170A620000D439 /* EditVideoModels.swift */,
+				FC37522B2B170A620000D439 /* EditVideoWorker.swift */,
+				FC37522C2B170A620000D439 /* EditVideoRouter.swift */,
+				FC3752362B170B230000D439 /* EditVideoConfigurator.swift */,
+			);
+			path = EditVideo;
+			sourceTree = "<group>";
+		};
 		FC4975852B0342CE00D8627F /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -651,6 +681,7 @@
 			children = (
 				19A169452B17D10500DB34C0 /* Mocks */,
 				193686732B15C489008902CD /* UserWorker.swift */,
+				FC42E4132B17AB69005D4956 /* VideoFileWorker.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -669,6 +700,7 @@
 				19A1691C2B176C2C00DB34C0 /* TagPlayList */,
 				FC930E6E2B0CD73B00AA48E3 /* Profile */,
 				FC5BE1152B148B540036366D /* EditProfile */,
+				FC3752292B170A050000D439 /* EditVideo */,
 				194552272B0479B600299768 /* BaseViewController.swift */,
 			);
 			path = Scenes;
@@ -873,6 +905,7 @@
 				83C35E1E2B10923C00D8DD5C /* PlaybackCell.swift in Sources */,
 				FC2511A42B045D6C004717BC /* SignUpModels.swift in Sources */,
 				FC767F932B1220CC0088CF9B /* NicknameDTO.swift in Sources */,
+				FC3752312B170A620000D439 /* EditVideoWorker.swift in Sources */,
 				19A169272B176C5F00DB34C0 /* TagPlayListViewController.swift in Sources */,
 				19A169252B176C5F00DB34C0 /* TagPlayListRouter.swift in Sources */,
 				FC68E2A12B023326001AABFF /* EndPoint.swift in Sources */,
@@ -887,6 +920,7 @@
 				FC5BE11C2B148D160036366D /* EditProfilePresenter.swift in Sources */,
 				FC68E2A32B0233BC001AABFF /* NetworkError.swift in Sources */,
 				FC3F3BD82B069EB30080E3A6 /* MapCarouselCollectionViewCell.swift in Sources */,
+				FC3752342B170A620000D439 /* EditVideoViewController.swift in Sources */,
 				19A169442B17C71C00DB34C0 /* Board.swift in Sources */,
 				194552252B0478B400299768 /* HomeViewController.swift in Sources */,
 				194552222B0478B400299768 /* HomeWorker.swift in Sources */,
@@ -901,6 +935,10 @@
 				19A1693A2B17BCC400DB34C0 /* MemberDTO.swift in Sources */,
 				194551F62B037F2D00299768 /* LoginViewController.swift in Sources */,
 				FC767FA52B125F430088CF9B /* UIViewController+.swift in Sources */,
+				FC3752332B170A620000D439 /* EditVideoModels.swift in Sources */,
+				FC3752322B170A620000D439 /* EditVideoRouter.swift in Sources */,
+				FC3752352B170A620000D439 /* EditVideoInteractor.swift in Sources */,
+				FC3752302B170A620000D439 /* EditVideoPresenter.swift in Sources */,
 				FCEE0FF22B036B6000195BBE /* LOButton.swift in Sources */,
 				FC5BE1212B148D170036366D /* EditProfileInteractor.swift in Sources */,
 				FC930E7C2B0CD80800AA48E3 /* ProfileConfigurator.swift in Sources */,
@@ -920,6 +958,7 @@
 				194551F42B037F2D00299768 /* LoginRouter.swift in Sources */,
 				FC4975992B03439000D8627F /* UIFont+.swift in Sources */,
 				FC5BE11E2B148D160036366D /* EditProfileRouter.swift in Sources */,
+				FC42E4142B17AB69005D4956 /* VideoFileWorker.swift in Sources */,
 				FC767F952B1222350088CF9B /* ProfileImageDTO.swift in Sources */,
 				19A169422B17C70C00DB34C0 /* Member.swift in Sources */,
 				194551F52B037F2D00299768 /* LoginModels.swift in Sources */,
@@ -927,6 +966,7 @@
 				19A169402B17C10300DB34C0 /* PostEndPointFactory.swift in Sources */,
 				835A619E2B068115002F22A5 /* PlaybackWorker.swift in Sources */,
 				1972CCD22B125ED700C3C762 /* UserDefaultStored.swift in Sources */,
+				FC3752372B170B230000D439 /* EditVideoConfigurator.swift in Sources */,
 				FC2511AD2B04EACD004717BC /* MapInteractor.swift in Sources */,
 				19C7AFD62B02584D003B35F2 /* KeychainStored.swift in Sources */,
 				FC930E802B0CFB0B00AA48E3 /* ProfileHeaderView.swift in Sources */,

--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 		835A61A62B0B4DDD002F22A5 /* Dashboard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 835A61A52B0B4DDD002F22A5 /* Dashboard-Regular.ttf */; };
 		835A61A92B0B5A31002F22A5 /* LoginConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A61A82B0B5A31002F22A5 /* LoginConfigurator.swift */; };
 		836C33872B15A29600ECAFB0 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C33862B15A29600ECAFB0 /* Toast.swift */; };
+		836C338B2B15D22C00ECAFB0 /* PlaybackConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C338A2B15D22C00ECAFB0 /* PlaybackConfigurator.swift */; };
+		836C338D2B15D91F00ECAFB0 /* VideoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */; };
+		836C338F2B160CC700ECAFB0 /* MemberDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C338E2B160CC700ECAFB0 /* MemberDTO.swift */; };
+		836C33912B17629400ECAFB0 /* MapRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C33902B17629400ECAFB0 /* MapRouter.swift */; };
 		83C35E1B2B108C3500D8DD5C /* PlaybackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C35E1A2B108C3500D8DD5C /* PlaybackView.swift */; };
 		83C35E1E2B10923C00D8DD5C /* PlaybackCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C35E1D2B10923C00D8DD5C /* PlaybackCell.swift */; };
 		FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC25119F2B045C0A004717BC /* SignUpInteractor.swift */; };
@@ -234,6 +238,10 @@
 		835A61A82B0B5A31002F22A5 /* LoginConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginConfigurator.swift; sourceTree = "<group>"; };
 		835A61AA2B0B85FD002F22A5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		836C33862B15A29600ECAFB0 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+		836C338A2B15D22C00ECAFB0 /* PlaybackConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackConfigurator.swift; sourceTree = "<group>"; };
+		836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDTO.swift; sourceTree = "<group>"; };
+		836C338E2B160CC700ECAFB0 /* MemberDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberDTO.swift; sourceTree = "<group>"; };
+		836C33902B17629400ECAFB0 /* MapRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapRouter.swift; sourceTree = "<group>"; };
 		83C35E1A2B108C3500D8DD5C /* PlaybackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackView.swift; sourceTree = "<group>"; };
 		83C35E1D2B10923C00D8DD5C /* PlaybackCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackCell.swift; sourceTree = "<group>"; };
 		FC25119F2B045C0A004717BC /* SignUpInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInteractor.swift; sourceTree = "<group>"; };
@@ -450,6 +458,8 @@
 				19A169372B17BCA800DB34C0 /* PostDTO.swift */,
 				19A169392B17BCC400DB34C0 /* MemberDTO.swift */,
 				19A1693B2B17BD1C00DB34C0 /* BoardDTO.swift */,
+				836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */,
+				836C338E2B160CC700ECAFB0 /* MemberDTO.swift */,
 			);
 			path = DTOs;
 			sourceTree = "<group>";
@@ -511,6 +521,7 @@
 				835A619B2B068115002F22A5 /* PlaybackViewController.swift */,
 				835A619C2B068115002F22A5 /* PlaybackInteractor.swift */,
 				83C35E1A2B108C3500D8DD5C /* PlaybackView.swift */,
+				836C338A2B15D22C00ECAFB0 /* PlaybackConfigurator.swift */,
 			);
 			path = Playback;
 			sourceTree = "<group>";
@@ -533,6 +544,7 @@
 				FC2511AA2B04EA6B004717BC /* MapConfigurator.swift */,
 				FC2511B02B04EAEC004717BC /* MapModels.swift */,
 				FC767FA92B126D080088CF9B /* LOAnnotation.swift */,
+				836C33902B17629400ECAFB0 /* MapRouter.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -947,6 +959,7 @@
 				FC930E7C2B0CD80800AA48E3 /* ProfileConfigurator.swift in Sources */,
 				FC2511A62B049020004717BC /* SignUpConfigurator.swift in Sources */,
 				194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */,
+				836C338F2B160CC700ECAFB0 /* MemberDTO.swift in Sources */,
 				FC767FAA2B126D080088CF9B /* LOAnnotation.swift in Sources */,
 				19A169472B17D12500DB34C0 /* MockTagPlayListWorker.swift in Sources */,
 				193686722B15BCA7008902CD /* UserEndPointFactory.swift in Sources */,
@@ -982,6 +995,7 @@
 				1972CCD82B13A2EC00C3C762 /* SignUpEndPointFactory.swift in Sources */,
 				19A169262B176C5F00DB34C0 /* TagPlayListModels.swift in Sources */,
 				FC767F842B1214A80088CF9B /* MockUserWorker.swift in Sources */,
+				836C338B2B15D22C00ECAFB0 /* PlaybackConfigurator.swift in Sources */,
 				FC930E782B0CD75C00AA48E3 /* ProfileModels.swift in Sources */,
 				FC68E29B2B02325D001AABFF /* Requestable.swift in Sources */,
 				FC2511A22B045C3F004717BC /* SignUpPresenter.swift in Sources */,
@@ -990,12 +1004,14 @@
 				FC68E29D2B02326A001AABFF /* Responsable.swift in Sources */,
 				FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */,
 				FC767F862B1214C10088CF9B /* CheckUserNameDTO.swift in Sources */,
+				836C338D2B15D91F00ECAFB0 /* VideoDTO.swift in Sources */,
 				FC5BE1232B1490660036366D /* EditProfileConfigurator.swift in Sources */,
 				1945522A2B04883800299768 /* UIView+.swift in Sources */,
 				FCE52FFA2B0FCB0A002CDB75 /* URLSession+.swift in Sources */,
 				19743C052B06940D001E405A /* PlayerView.swift in Sources */,
 				83C35E1B2B108C3500D8DD5C /* PlaybackView.swift in Sources */,
 				835A61A02B068115002F22A5 /* PlaybackModels.swift in Sources */,
+				836C33912B17629400ECAFB0 /* MapRouter.swift in Sources */,
 				19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */,
 				FC9BB82C2B094E5500EB72A9 /* UICollectionViewLayout+.swift in Sources */,
 				194552232B0478B400299768 /* HomeRouter.swift in Sources */,

--- a/iOS/Layover/Layover/AppDelegate.swift
+++ b/iOS/Layover/Layover/AppDelegate.swift
@@ -14,7 +14,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+
+        // remove keychain data when app is first launched
+        if System.isFirstLaunch() {
+            AuthManager.shared.logout()
+        }
+
+        // kakao
         guard let KAKAO_APP_KEY = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as? String else { return true }
         KakaoSDK.initSDK(appKey: KAKAO_APP_KEY)
         return true

--- a/iOS/Layover/Layover/Models/Board.swift
+++ b/iOS/Layover/Layover/Models/Board.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Board {
+struct Board: Hashable {
     let identifier: Int
     let title: String
     let description: String?

--- a/iOS/Layover/Layover/Models/Member.swift
+++ b/iOS/Layover/Layover/Models/Member.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Member {
+struct Member: Hashable {
     let identifier: Int
     let username: String
     let introduce: String

--- a/iOS/Layover/Layover/Models/Post.swift
+++ b/iOS/Layover/Layover/Models/Post.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Post {
+struct Post: Hashable {
     let member: Member
     let board: Board
     let tag: [String]

--- a/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MemberDTO: Decodable {
+struct MemberDTO: Codable {
     let id: Int
     let username, introduce: String
     let profileImageURL: String

--- a/iOS/Layover/Layover/Network/DTOs/VideoDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/VideoDTO.swift
@@ -1,0 +1,26 @@
+//
+//  VideoDTO.swift
+//  Layover
+//
+//  Created by 황지웅 on 11/28/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+struct VideoDTO: Codable {
+    let title: String
+    let content: String
+    let location: String
+    let tags: [String]
+    // TODO: 프로필 완성되면 변경
+    let member: MemberDTO
+    let sdURL: URL
+    let hdURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case title, content, location, tags, member
+        case sdURL = "sd_url"
+        case hdURL = "hd_url"
+    }
+}

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -38,9 +38,7 @@ final class EditProfileViewController: BaseViewController {
 
     private lazy var editProfileImageButton: LOCircleButton = {
         let button = LOCircleButton(style: .photo, diameter: 32)
-        button.addAction(UIAction { _ in
-            self.present(self.phPickerViewController, animated: true)
-        }, for: .touchUpInside)
+        button.addTarget(self, action: #selector(editProfileImageButtonDidTap), for: .touchUpInside)
         return button
     }()
 
@@ -190,6 +188,10 @@ final class EditProfileViewController: BaseViewController {
 
         let request = Models.CheckNicknameDuplication.Request(nickname: nickname)
         interactor?.checkDuplication(with: request)
+    }
+
+    @objc private func editProfileImageButtonDidTap() {
+        self.present(phPickerViewController, animated: true)
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoConfigurator.swift
@@ -1,0 +1,35 @@
+//
+//  EditVideoConfigurator.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+final class EditVideoConfigurator: Configurator {
+
+    typealias ViewController = EditVideoViewController
+
+    static let shared = EditVideoConfigurator()
+
+    private init() { }
+
+    func configure(_ viewController: ViewController) {
+        let viewController = viewController
+        let videoFileWorker = VideoFileWorker()
+        let interactor = EditVideoInteractor()
+        let presenter = EditVideoPresenter()
+        let router = EditVideoRouter()
+
+        router.viewController = viewController
+        router.dataStore = interactor
+        viewController.interactor = interactor
+        viewController.router = router
+        interactor.presenter = presenter
+        interactor.videoFileWorker = videoFileWorker
+        presenter.viewController = viewController
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoInteractor.swift
@@ -1,0 +1,54 @@
+//
+//  EditVideoInteractor.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import AVFoundation
+import UIKit
+
+protocol EditVideoBusinessLogic {
+    func fetchVideo(request: EditVideoModels.FetchVideo.Request)
+    func deleteVideo()
+}
+
+protocol EditVideoDataStore {
+    var videoURL: URL? { get set }
+}
+
+final class EditVideoInteractor: EditVideoBusinessLogic, EditVideoDataStore {
+
+    // MARK: - Properties
+
+    typealias Models = EditVideoModels
+
+    var videoFileWorker: VideoFileWorker?
+    var presenter: EditVideoPresentationLogic?
+
+    var videoURL: URL?
+
+    func fetchVideo(request: EditVideoModels.FetchVideo.Request) {
+        let isEdited = request.editedVideoURL != nil
+        guard let videoURL = isEdited ? request.editedVideoURL : videoURL else { return }
+
+        Task {
+            let duration = try await AVAsset(url: videoURL).load(.duration)
+            let seconds = CMTimeGetSeconds(duration)
+            let response = Models.FetchVideo.Response(isEdited: isEdited,
+                                                      videoURL: videoURL,
+                                                      duration: seconds,
+                                                      isWithinRange: request.videoRange ~= seconds)
+            await MainActor.run {
+                presenter?.presentVideo(with: response)
+            }
+        }
+    }
+
+    func deleteVideo() {
+        guard let videoURL else { return }
+        videoFileWorker?.delete(at: videoURL)
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoModels.swift
@@ -1,0 +1,32 @@
+//
+//  EditVideoModels.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+enum EditVideoModels {
+
+    enum FetchVideo {
+        struct Request {
+            var editedVideoURL: URL?
+            var videoRange: ClosedRange<Double> = 3.0...60.0
+        }
+        struct Response {
+            let isEdited: Bool
+            let videoURL: URL
+            let duration: Double
+            var isWithinRange: Bool
+        }
+        struct ViewModel {
+            let isEdited: Bool
+            let videoURL: URL
+            let duration: Double
+            let canNext: Bool
+        }
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoPresenter.swift
@@ -1,0 +1,29 @@
+//
+//  EditVideoPresenter.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+protocol EditVideoPresentationLogic {
+    func presentVideo(with response: EditVideoModels.FetchVideo.Response)
+}
+
+final class EditVideoPresenter: EditVideoPresentationLogic {
+
+    // MARK: - Properties
+
+    typealias Models = EditVideoModels
+    weak var viewController: EditVideoDisplayLogic?
+
+    func presentVideo(with response: EditVideoModels.FetchVideo.Response) {
+        let viewModel = Models.FetchVideo.ViewModel(isEdited: response.isEdited,
+                                                    videoURL: response.videoURL,
+                                                    duration: response.duration,
+                                                    canNext: response.isWithinRange)
+        viewController?.displayVideo(viewModel: viewModel)
+    }
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoRouter.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoRouter.swift
@@ -1,0 +1,32 @@
+//
+//  EditVideoRouter.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+protocol EditVideoRoutingLogic {
+    func routeToNext()
+}
+
+protocol EditVideoDataPassing {
+    var dataStore: EditVideoDataStore? { get }
+}
+
+final class EditVideoRouter: NSObject, EditVideoRoutingLogic, EditVideoDataPassing {
+
+    // MARK: - Properties
+
+    weak var viewController: EditVideoViewController?
+    var dataStore: EditVideoDataStore?
+
+    // MARK: - Routing
+
+    func routeToNext() {
+
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoViewController.swift
@@ -1,0 +1,150 @@
+//
+//  EditVideoViewController.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import AVFoundation
+import UIKit
+
+protocol EditVideoDisplayLogic: AnyObject {
+    func displayVideo(viewModel: EditVideoModels.FetchVideo.ViewModel)
+}
+
+final class EditVideoViewController: BaseViewController {
+
+    // MARK: - UI Components
+
+    private let loopingPlayerView: LoopingPlayerView = {
+        let playerView = LoopingPlayerView()
+        return playerView
+    }()
+
+    private lazy var soundButton: LOCircleButton = {
+        let button = LOCircleButton(style: .sound, diameter: 52)
+        button.addTarget(self, action: #selector(soundButtonDidTap), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var cutButton: LOCircleButton = {
+        let button = LOCircleButton(style: .scissors, diameter: 52)
+        button.addTarget(self, action: #selector(cutButtonDidTap), for: .touchUpInside)
+        return button
+    }()
+
+    private let nextButton: LOButton = {
+        let button = LOButton(style: .basic)
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+
+    // MARK: - Properties
+
+    typealias Models = EditVideoModels
+    var router: (NSObjectProtocol & EditVideoRoutingLogic & EditVideoDataPassing)?
+    var interactor: EditVideoBusinessLogic?
+
+    private var originalVideoURL: URL?
+
+    // MARK: - Object lifecycle
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        setup()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setup()
+    }
+
+    // MARK: - Setup
+
+    private func setup() {
+        EditVideoConfigurator.shared.configure(self)
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        interactor?.fetchVideo(request: Models.FetchVideo.Request(editedVideoURL: nil))
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        interactor?.deleteVideo()
+    }
+
+    override func setConstraints() {
+        super.setConstraints()
+        view.addSubviews(loopingPlayerView, soundButton, cutButton, nextButton)
+        view.subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            loopingPlayerView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            loopingPlayerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            loopingPlayerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            loopingPlayerView.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -19),
+
+            soundButton.trailingAnchor.constraint(equalTo: cutButton.leadingAnchor, constant: -9),
+            soundButton.bottomAnchor.constraint(equalTo: loopingPlayerView.bottomAnchor, constant: -15),
+
+            cutButton.trailingAnchor.constraint(equalTo: loopingPlayerView.trailingAnchor, constant: -15),
+            cutButton.bottomAnchor.constraint(equalTo: loopingPlayerView.bottomAnchor, constant: -15),
+
+            nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -18),
+            nextButton.widthAnchor.constraint(equalToConstant: 117),
+            nextButton.heightAnchor.constraint(equalToConstant: 50),
+            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -13)
+        ])
+    }
+
+    @objc private func soundButtonDidTap() {
+        loopingPlayerView.player?.isMuted.toggle()
+        soundButton.isSelected.toggle()
+    }
+
+    @objc private func cutButtonDidTap() {
+        guard let videoPath = originalVideoURL?.path() else { return }
+        if UIVideoEditorController.canEditVideo(atPath: videoPath) {
+            let editController = UIVideoEditorController()
+            editController.videoPath = videoPath
+            editController.videoMaximumDuration = 60.0
+            editController.modalPresentationStyle = .overCurrentContext
+            editController.videoQuality = .typeHigh
+            editController.delegate = self
+            self.present(editController, animated: true)
+        }
+    }
+
+}
+
+extension EditVideoViewController: UINavigationControllerDelegate, UIVideoEditorControllerDelegate {
+
+    func videoEditorController(_ editor: UIVideoEditorController, didSaveEditedVideoToPath editedVideoPath: String) {
+        let editedVideoURL = NSURL(fileURLWithPath: editedVideoPath) as URL
+        interactor?.fetchVideo(request: EditVideoModels.FetchVideo.Request(editedVideoURL: editedVideoURL))
+        dismiss(animated: true)
+    }
+
+}
+
+extension EditVideoViewController: EditVideoDisplayLogic {
+
+    func displayVideo(viewModel: EditVideoModels.FetchVideo.ViewModel) {
+        if !viewModel.isEdited {
+            self.originalVideoURL = viewModel.videoURL
+        }
+        loopingPlayerView.disable()
+        loopingPlayerView.prepareVideo(with: viewModel.videoURL,
+                                       loopStart: .zero,
+                                       duration: viewModel.duration)
+        loopingPlayerView.play()
+        nextButton.isEnabled = viewModel.canNext
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/EditVideo/EditVideoWorker.swift
+++ b/iOS/Layover/Layover/Scenes/EditVideo/EditVideoWorker.swift
@@ -1,0 +1,17 @@
+//
+//  EditVideoWorker.swift
+//  Layover
+//
+//  Created by kong on 2023/11/29.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import UIKit
+
+final class EditVideoWorker {
+
+    // MARK: - Properties
+
+    typealias Models = EditVideoModels
+
+}

--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -35,6 +35,9 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
         loopingPlayerView.isPlaying
     }
 
+    // 다른 방법도 많이 알려주세요
+    var moveToPlaybackSceneCallback: (() -> Void) = { }
+
     // MARK: - Object lifecycle
 
     override init(frame: CGRect) {
@@ -115,6 +118,16 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     }
 
     func pauseVideo() {
+        loopingPlayerView.pause()
+    }
+
+    func addLoopingViewGesture() {
+        let loopingViewGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(moveToPlaybackScene))
+        loopingPlayerView.addGestureRecognizer(loopingViewGesture)
+    }
+
+    @objc func moveToPlaybackScene() {
+        moveToPlaybackSceneCallback()
         loopingPlayerView.pause()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
@@ -16,14 +16,15 @@ final class HomeConfigurator: Configurator {
 
     func configure(_ viewController: HomeViewController) {
         let router = HomeRouter()
-        router.viewController = viewController
-
         let presenter = HomePresenter()
-        presenter.viewController = viewController
-
         let interactor = HomeInteractor()
-        interactor.presenter = presenter
+        let videoFileWorker = VideoFileWorker()
 
+        router.viewController = viewController
+        router.dataStore = interactor
+        presenter.viewController = viewController
+        interactor.presenter = presenter
+        interactor.videoFileWorker = videoFileWorker
         viewController.router = router
         viewController.interactor = interactor
     }

--- a/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeConfigurator.swift
@@ -27,5 +27,7 @@ final class HomeConfigurator: Configurator {
         interactor.videoFileWorker = videoFileWorker
         viewController.router = router
         viewController.interactor = interactor
+
+        router.dataStore = interactor
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -10,10 +10,13 @@ import UIKit
 
 protocol HomeBusinessLogic {
     func fetchVideos(with: HomeModels.CarouselVideos.Request)
+    func moveToPlaybackScene(with: HomeModels.MoveToPlaybackScene.Request)
     func selectVideo(with request: HomeModels.SelectVideo.Request)
 }
 
 protocol HomeDataStore {
+    var videos: [Post]? { get set }
+    var index: Int? { get set }
     var selectedVideoURL: URL? { get set }
 }
 
@@ -26,6 +29,10 @@ final class HomeInteractor: HomeDataStore {
     var videoFileWorker: VideoFileWorkerProtocol?
     var presenter: HomePresentationLogic?
 
+    var videos: [Post]?
+
+    var index: Int?
+    
     var selectedVideoURL: URL?
 
     func selectVideo(with request: Models.SelectVideo.Request) {
@@ -46,5 +53,11 @@ extension HomeInteractor: HomeBusinessLogic {
             URL(string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8")!
         ])
         presenter?.presentVideoURL(with: response)
+    }
+
+    func moveToPlaybackScene(with request: Models.MoveToPlaybackScene.Request) {
+        videos = request.videos
+        index = request.index
+        presenter?.presentPlaybackScene()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -10,10 +10,11 @@ import UIKit
 
 protocol HomeBusinessLogic {
     func fetchVideos(with: HomeModels.CarouselVideos.Request)
+    func selectVideo(with request: HomeModels.SelectVideo.Request)
 }
 
 protocol HomeDataStore {
-
+    var selectedVideoURL: URL? { get set }
 }
 
 final class HomeInteractor: HomeDataStore {
@@ -22,7 +23,15 @@ final class HomeInteractor: HomeDataStore {
 
     typealias Models = HomeModels
 
+    var videoFileWorker: VideoFileWorkerProtocol?
     var presenter: HomePresentationLogic?
+
+    var selectedVideoURL: URL?
+
+    func selectVideo(with request: Models.SelectVideo.Request) {
+        selectedVideoURL = videoFileWorker?.copyToNewURL(at: request.videoURL)
+    }
+
 }
 
 // MARK: - Use Case

--- a/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
@@ -38,4 +38,21 @@ enum HomeModels {
 
         }
     }
+
+    enum MoveToPlaybackScene {
+        struct Request {
+            let index: Int
+            let videos: [Post]
+        }
+
+        struct Response {
+            let index: Int
+            let videos: [Post]
+        }
+
+        struct ViewModel {
+            let index: Int
+            let videos: [Post]
+        }
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
@@ -17,11 +17,25 @@ enum HomeModels {
         }
 
         struct Response {
-            var videoURLs: [URL]
+            let videoURLs: [URL]
         }
 
         struct ViewModel {
-            var videoURLs: [URL]
+            let videoURLs: [URL]
+        }
+    }
+
+    enum SelectVideo {
+        struct Request {
+            let videoURL: URL
+        }
+
+        struct Response {
+
+        }
+
+        struct ViewModel {
+
         }
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol HomePresentationLogic {
     func presentVideoURL(with response: HomeModels.CarouselVideos.Response)
+    func presentPlaybackScene()
 }
 
 final class HomePresenter: HomePresentationLogic {
@@ -24,5 +25,11 @@ final class HomePresenter: HomePresentationLogic {
     func presentVideoURL(with response: HomeModels.CarouselVideos.Response) {
         let viewModel = HomeModels.CarouselVideos.ViewModel(videoURLs: response.videoURLs)
         viewController?.displayVideoURLs(with: viewModel)
+    }
+
+    // MARK: - UseCase Present PlaybackScene
+
+    func presentPlaybackScene() {
+        viewController?.routeToPlayback()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol HomeRoutingLogic {
     func routeToNext()
+    func routeToPlayback()
     func routeToEditVideo()
 }
 
@@ -17,7 +18,7 @@ protocol HomeDataPassing {
     var dataStore: HomeDataStore? { get }
 }
 
-class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
+final class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
 
     // MARK: - Properties
 
@@ -42,6 +43,23 @@ class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
         destination.videoURL = videoURL
         nextViewController.hidesBottomBarWhenPushed = true
         viewController?.navigationController?.pushViewController(nextViewController, animated: true)
+    }
+
+    func routeToPlayback() {
+        let playbackViewController: PlaybackViewController = PlaybackViewController()
+        guard let source = dataStore,
+              let destination = playbackViewController.router?.dataStore
+        else { return }
+        destination.parentView = .home
+        destination.index = source.index
+        destination.videos = transData(videos: source.videos ?? [])
+        viewController?.navigationController?.pushViewController(playbackViewController, animated: true)
+    }
+
+    private func transData(videos: [Post]) -> [PlaybackModels.PlaybackVideo] {
+        videos.map { video in
+            return PlaybackModels.PlaybackVideo(post: video)
+        }
     }
 
     // MARK: - Data Passing

--- a/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol HomeRoutingLogic {
     func routeToNext()
+    func routeToEditVideo()
 }
 
 protocol HomeDataPassing {
@@ -28,6 +29,19 @@ class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
     func routeToNext() {
         let nextViewController = MainTabBarViewController()
         viewController?.navigationController?.setViewControllers([nextViewController], animated: true)
+    }
+
+    func routeToEditVideo() {
+        let nextViewController = EditVideoViewController()
+        guard let source = dataStore,
+              var destination = nextViewController.router?.dataStore,
+              let videoURL = source.selectedVideoURL
+        else { return }
+
+        // Data Passing
+        destination.videoURL = videoURL
+        nextViewController.hidesBottomBarWhenPushed = true
+        viewController?.navigationController?.pushViewController(nextViewController, animated: true)
     }
 
     // MARK: - Data Passing

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 
 protocol HomeDisplayLogic: AnyObject {
     func displayVideoURLs(with viewModel: HomeModels.CarouselVideos.ViewModel)
+    func routeToPlayback()
 }
 
 final class HomeViewController: BaseViewController {
@@ -57,6 +58,64 @@ final class HomeViewController: BaseViewController {
                                                             for: indexPath) as? HomeCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.setVideo(url: url, loopingAt: .zero)
         cell.configure(title: "요리왕 비룡 데뷔", tags: ["#천상의맛", "#갈갈갈", "#빨리주세요"])
+        cell.moveToPlaybackSceneCallback = {
+            self.interactor?.moveToPlaybackScene(
+                with: Models.MoveToPlaybackScene.Request(
+                    index: indexPath.row,
+                    videos: [
+                        Post(
+                            member: Member(
+                                identifier: 1,
+                                username: "찹모찌",
+                                introduce: "찹모찌데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 1,
+                                title: "찹찹찹",
+                                description: "찹모찌의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["찹", "모", "찌"]
+                            ),
+                        Post(
+                            member: Member(
+                                identifier: 2,
+                                username: "로인설",
+                                introduce: "로인설데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 2,
+                                title: "설설설",
+                                description: "로인설의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["로", "인", "설"]
+                            ),
+                        Post(
+                            member: Member(
+                                identifier: 3,
+                                username: "콩콩콩",
+                                introduce: "콩콩콩데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 1,
+                                title: "콩콩콩",
+                                description: "콩콩콩의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["콩", "콩", "콩"]
+                            )
+                    ]
+                )
+            )
+        }
+        cell.addLoopingViewGesture()
         return cell
     }
 
@@ -222,5 +281,9 @@ extension HomeViewController: HomeDisplayLogic {
         carouselDatasource.apply(snapshot) {
             self.playVideoAtCenterCell()
         }
+    }
+
+    func routeToPlayback() {
+        router?.routeToPlayback()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -45,7 +45,7 @@ final class LoginRouter: LoginRoutingLogic, LoginDataPassing {
     func navigateToAppleSignUp() {
         let signUpViewController = SignUpViewController()
         guard let source = dataStore,
-              var destination = signUpViewController.router?.dataStore
+              let destination = signUpViewController.router?.dataStore
         else { return }
 
         destination.signUpType = .apple

--- a/iOS/Layover/Layover/Scenes/Map/MapConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapConfigurator.swift
@@ -19,8 +19,12 @@ final class MapConfigurator: Configurator {
         let viewController = viewController
         let interactor = MapInteractor()
         let presenter = MapPresenter()
+        let router = MapRouter()
+        router.viewController = viewController
         viewController.interactor = interactor
         interactor.presenter = presenter
         presenter.viewController = viewController
+        viewController.router = router
+        router.dataStore = interactor
     }
 }

--- a/iOS/Layover/Layover/Scenes/Map/MapInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapInteractor.swift
@@ -12,9 +12,13 @@ import Foundation
 protocol MapBusinessLogic {
     func checkLocationAuthorizationStatus()
     func fetchVideos()
+    func moveToPlaybackScene(with: MapModels.MoveToPlaybackScene.Request)
 }
 
-protocol MapDataStore { }
+protocol MapDataStore { 
+    var videos: [Post]? { get set }
+    var index: Int? { get set }
+}
 
 final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
 
@@ -28,6 +32,10 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
 
     private var longitude: Double?
 
+    var index: Int?
+
+    var videos: [Post]?
+    
     var presenter: MapPresentationLogic?
 
     override init() {
@@ -49,6 +57,12 @@ final class MapInteractor: NSObject, MapBusinessLogic, MapDataStore {
                                    "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"]
             .compactMap { URL(string: $0) }
         presenter?.presentFetchedVideos(with: MapModels.FetchVideo.Reponse(videoURLs: dummyURLs))
+    }
+
+    func moveToPlaybackScene(with request: Models.MoveToPlaybackScene.Request) {
+        videos = request.videos
+        index = request.index
+        presenter?.presentPlaybackScene()
     }
 
     private func checkCurrentLocationAuthorization(for status: CLAuthorizationStatus) {

--- a/iOS/Layover/Layover/Scenes/Map/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapModels.swift
@@ -30,4 +30,24 @@ enum MapModels {
             }
         }
     }
+
+    // MARK: - Move To Playback Scene
+
+    enum MoveToPlaybackScene {
+        struct Request {
+            let index: Int
+            let videos: [Post]
+        }
+
+        struct Response {
+            let index: Int
+            let videos: [Post]
+        }
+
+        struct ViewModel {
+            let index: Int
+            let videos: [Post]
+        }
+    }
+
 }

--- a/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
@@ -12,6 +12,7 @@ protocol MapPresentationLogic {
     func presentCurrentLocation()
     func presentDefaultLocation()
     func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse)
+    func presentPlaybackScene()
 }
 
 final class MapPresenter: MapPresentationLogic {
@@ -32,5 +33,9 @@ final class MapPresenter: MapPresentationLogic {
     func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse) {
         let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURL: $0) })
         viewController?.displayFetchedVideos(viewModel: viewModel)
+    }
+
+    func presentPlaybackScene() {
+        viewController?.routeToPlayback()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Map/MapRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapRouter.swift
@@ -1,0 +1,45 @@
+//
+//  MapRouter.swift
+//  Layover
+//
+//  Created by 황지웅 on 11/29/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+protocol MapRoutingLogic {
+    func routeToPlayback()
+}
+
+protocol MapDataPassing {
+    var dataStore: MapDataStore? { get }
+}
+
+final class MapRouter: MapRoutingLogic, MapDataPassing {
+
+    // MARK: - Properties
+
+    weak var viewController: MapViewController?
+    var dataStore: MapDataStore?
+
+    // MARK: - Routing
+
+    func routeToPlayback() {
+        let playbackViewController: PlaybackViewController = PlaybackViewController()
+        guard let source = dataStore,
+              let destination = playbackViewController.router?.dataStore
+        else { return }
+        destination.parentView = .other
+        destination.index = source.index
+        destination.videos = transData(videos: source.videos ?? [])
+        viewController?.navigationController?.pushViewController(playbackViewController, animated: true)
+    }
+
+    private func transData(videos: [Post]) -> [PlaybackModels.PlaybackVideo] {
+        videos.map { video in
+            return PlaybackModels.PlaybackVideo(post: video)
+        }
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 
 protocol MapDisplayLogic: AnyObject {
     func displayFetchedVideos(viewModel: MapModels.FetchVideo.ViewModel)
+    func routeToPlayback()
 }
 
 final class MapViewController: BaseViewController {
@@ -61,6 +62,64 @@ final class MapViewController: BaseViewController {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MapCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? MapCarouselCollectionViewCell else { return UICollectionViewCell() }
         cell.configure(url: item.videoURL)
+        cell.moveToPlaybackSceneCallback = {
+            self.interactor?.moveToPlaybackScene(
+                with: Models.MoveToPlaybackScene.Request(
+                    index: indexPath.row,
+                    videos: [
+                        Post(
+                            member: Member(
+                                identifier: 1,
+                                username: "찹모찌",
+                                introduce: "찹모찌데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 1,
+                                title: "찹찹찹",
+                                description: "찹모찌의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["찹", "모", "찌"]
+                            ),
+                        Post(
+                            member: Member(
+                                identifier: 2,
+                                username: "로인설",
+                                introduce: "로인설데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 2,
+                                title: "설설설",
+                                description: "로인설의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["로", "인", "설"]
+                            ),
+                        Post(
+                            member: Member(
+                                identifier: 3,
+                                username: "콩콩콩",
+                                introduce: "콩콩콩데스",
+                                profileImageURL: URL(string: "https://i.ibb.co/qML8vdN/2023-11-25-9-08-01.png")!),
+                            board: Board(
+                                identifier: 1,
+                                title: "콩콩콩",
+                                description: "콩콩콩의 뜻은 뭘까?",
+                                thumbnailImageURL: nil,
+                                videoURL: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!,
+                                latitude: nil,
+                                longitude: nil),
+                            tag: ["콩", "콩", "콩"]
+                            )
+                    ]
+                )
+            )
+        }
+        cell.addLoopingViewGesture()
         return cell
     }
 
@@ -69,6 +128,7 @@ final class MapViewController: BaseViewController {
     typealias Models = MapModels
     typealias ViewModel = Models.FetchVideo.ViewModel
     var interactor: MapBusinessLogic?
+    var router: (MapRoutingLogic & MapDataPassing)?
 
     private lazy var carouselCollectionViewHeight: NSLayoutConstraint = carouselCollectionView.heightAnchor.constraint(equalToConstant: 0)
 
@@ -215,6 +275,10 @@ extension MapViewController: MapDisplayLogic {
         snapshot.appendSections([UUID()])
         snapshot.appendItems(viewModel.videoDataSources)
         carouselDatasource.apply(snapshot)
+    }
+
+    func routeToPlayback() {
+        router?.routeToPlayback()
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/Map/Views/MapCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Map/Views/MapCarouselCollectionViewCell.swift
@@ -25,6 +25,8 @@ final class MapCarouselCollectionViewCell: UICollectionViewCell {
         render()
     }
 
+    var moveToPlaybackSceneCallback: (() -> Void) = { }
+
     func configure(url: URL) {
         loopingPlayerView.prepareVideo(with: url,
                                        timeRange: CMTimeRange(start: .zero, duration: CMTime(value: 1800, timescale: 600)))
@@ -48,4 +50,13 @@ final class MapCarouselCollectionViewCell: UICollectionViewCell {
         clipsToBounds = true
     }
 
+    func addLoopingViewGesture() {
+        let loopingViewGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(moveToPlaybackScene))
+        loopingPlayerView.addGestureRecognizer(loopingViewGesture)
+    }
+
+    @objc func moveToPlaybackScene() {
+        moveToPlaybackSceneCallback()
+        loopingPlayerView.pause()
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -22,8 +22,10 @@ final class PlaybackCell: UICollectionViewCell {
     }
 
     // TODO: VideoModel 받아서 처리
-    func setPlaybackContents(title: String) {
-        playbackView.descriptionView.titleLabel.text = title
+    func setPlaybackContents(viewModel: PlaybackModels.PlaybackVideo) {
+        playbackView.descriptionView.titleLabel.text = viewModel.post.board.title
+        playbackView.descriptionView.setText(viewModel.post.board.description ?? "")
+
     }
 
     func addAVPlayer(url: URL) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackConfigurator.swift
@@ -1,0 +1,33 @@
+//
+//  PlaybackConfigurator.swift
+//  Layover
+//
+//  Created by 황지웅 on 11/28/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+final class PlaybackConfigurator: Configurator {
+    typealias ViewController = PlaybackViewController
+
+    static let shared = PlaybackConfigurator()
+
+    private init() { }
+
+    func configure(_ viewController: PlaybackViewController) {
+        let viewController: PlaybackViewController = viewController
+        let interactor: PlaybackInteractor = PlaybackInteractor()
+        let presenter: PlaybackPresenter = PlaybackPresenter()
+        let worker: PlaybackWorker = PlaybackWorker()
+        let router: PlaybackRouter = PlaybackRouter()
+
+        router.viewController = viewController
+        router.dataStore = interactor
+        viewController.interactor = interactor
+        viewController.router = router
+        interactor.presenter = presenter
+        interactor.worker = worker
+        presenter.viewController = viewController
+    }
+}

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
@@ -9,17 +9,25 @@
 import UIKit
 
 protocol PlaybackBusinessLogic {
-    func fetchFromLocalDataStore(with request: PlaybackModels.FetchFromLocalDataStore.Request)
-    func fetchFromRemoteDataStore(with request: PlaybackModels.FetchFromRemoteDataStore.Request)
-    func trackAnalytics(with request: PlaybackModels.TrackAnalytics.Request)
-    func performPlayback(with request: PlaybackModels.PerformPlayback.Request)
+    func displayVideoList()
+    func moveInitialPlaybackCell()
+    func hidePlayerSlider()
+    func setInitialPlaybackCell()
+    func leavePlaybackView()
+    func playInitialPlaybackCell(with request: PlaybackModels.DisplayPlaybackVideo.Request)
+    func playVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request)
+    func playTeleportVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request)
 }
 
-protocol PlaybackDataStore {
-    var exampleVariable: String? { get set }
+protocol PlaybackDataStore: AnyObject {
+    var videos: [PlaybackModels.PlaybackVideo]? { get set }
+    var parentView: PlaybackModels.ParentView? { get set }
+    var prevCell: PlaybackCell? { get set }
+    var index: Int? { get set }
+    var isTeleport: Bool? { get set }
 }
 
-class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
+final class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
 
     // MARK: - Properties
 
@@ -28,59 +36,118 @@ class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
     lazy var worker = PlaybackWorker()
     var presenter: PlaybackPresentationLogic?
 
-    var exampleVariable: String?
+    var videos: [PlaybackModels.PlaybackVideo]?
 
-    // MARK: - Use Case - Fetch From Local DataStore
+    var parentView: Models.ParentView?
 
-    func fetchFromLocalDataStore(with request: PlaybackModels.FetchFromLocalDataStore.Request) {
-        let response = Models.FetchFromLocalDataStore.Response()
-        presenter?.presentFetchFromLocalDataStore(with: response)
-    }
+    var prevCell: PlaybackCell?
 
-    // MARK: - Use Case - Fetch From Remote DataStore
+    var index: Int?
 
-    func fetchFromRemoteDataStore(with request: PlaybackModels.FetchFromRemoteDataStore.Request) {
-        // fetch something from backend and return the values here
-        // <#Network Worker Instance#>.fetchFromRemoteDataStore(completion: { [weak self] code in
-        //     let response = Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
-        //     self?.presenter?.presentFetchFromRemoteDataStore(with: response)
-        // })
-    }
+    var isTeleport: Bool?
 
-    // MARK: - Use Case - Track Analytics
+    // MARK: - UseCase Load Video List
 
-    func trackAnalytics(with request: PlaybackModels.TrackAnalytics.Request) {
-        // call analytics library/wrapper here to track analytics
-        // <#Analytics Worker Instance#>.trackAnalytics(event: request.event)
-
-        let response = Models.TrackAnalytics.Response()
-        presenter?.presentTrackAnalytics(with: response)
-    }
-
-    // MARK: - Use Case - Playback
-
-    func performPlayback(with request: PlaybackModels.PerformPlayback.Request) {
-        let error = worker.validate(exampleVariable: request.exampleVariable)
-
-        if let error = error {
-            let response = Models.PerformPlayback.Response(error: error)
-            presenter?.presentPerformPlayback(with: response)
+    func displayVideoList() {
+        guard let parentView: Models.ParentView else {
             return
         }
-
-        // <#Network Worker Instance#>.performPlayback(completion: { [weak self, weak request] isSuccessful, error in
-        //     self?.completion(request?.exampleVariable, isSuccessful, error)
-        // })
-    }
-
-    private func completion(_ exampleVariable: String?, _ isSuccessful: Bool, _ error: Models.PlaybackError?) {
-        if isSuccessful {
-            // do something on success
-            let goodExample = exampleVariable ?? ""
-            self.exampleVariable = goodExample
+        guard var videos: [PlaybackModels.PlaybackVideo] else {
+            return
         }
-
-        let response = Models.PerformPlayback.Response(error: error)
-        presenter?.presentPerformPlayback(with: response)
+        if parentView == .other {
+            videos = worker.makeInfiniteScroll(videos: videos)
+            self.videos = videos
+        }
+        let response: Models.LoadPlaybackVideoList.Response = Models.LoadPlaybackVideoList.Response(videos: videos)
+        presenter?.presentVideoList(with: response)
     }
+
+
+    func moveInitialPlaybackCell() {
+        let response: Models.SetInitialPlaybackCell.Response = Models.SetInitialPlaybackCell.Response(indexPathRow: index ?? 0)
+        if parentView == .other {
+            presenter?.presentSetCellIfInfinite()
+        } else {
+            presenter?.presentMoveInitialPlaybackCell(with: response)
+        }
+    }
+
+    func setInitialPlaybackCell() {
+        guard let parentView else { return }
+        guard let index else { return }
+        let response: Models.SetInitialPlaybackCell.Response
+        switch parentView {
+        case .home:
+            response = Models.SetInitialPlaybackCell.Response(indexPathRow: index)
+        case .other:
+            response = Models.SetInitialPlaybackCell.Response(indexPathRow: index + 1)
+        }
+        presenter?.presentSetInitialPlaybackCell(with: response)
+    }
+
+    // MARK: - UseCase Playback Video
+
+    func playInitialPlaybackCell(with request: PlaybackModels.DisplayPlaybackVideo.Request) {
+        prevCell = request.curCell
+        let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: nil, curCell: request.curCell)
+        presenter?.presentPlayInitialPlaybackCell(with: response)
+    }
+
+    func hidePlayerSlider() {
+        let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: nil)
+        presenter?.presentHidePlayerSlider(with: response)
+    }
+
+    func playVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request) {
+        guard let videos else { return }
+        var response: Models.DisplayPlaybackVideo.Response
+        if prevCell == request.curCell {
+            response = Models.DisplayPlaybackVideo.Response(prevCell: nil, curCell: prevCell)
+            presenter?.presentShowPlayerSlider(with: response)
+            isTeleport = false
+            return
+        }
+        // Home이 아닌 다른 뷰에서 왔을 경우(로드한 목록 무한 반복)
+        if parentView == .other {
+            if request.indexPathRow == (videos.count - 1) {
+                response = Models.DisplayPlaybackVideo.Response(indexPathRow: 1, prevCell: prevCell, curCell: nil)
+            } else if request.indexPathRow == 0 {
+                response = Models.DisplayPlaybackVideo.Response(indexPathRow: videos.count - 2, prevCell: prevCell, curCell: nil)
+            } else {
+                response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: request.curCell)
+                prevCell = request.curCell
+                presenter?.presentMoveCellNext(with: response)
+                isTeleport = false
+                return
+            }
+            isTeleport = true
+            presenter?.presentTeleportCell(with: response)
+            return
+        }
+        // Home이면 다음 셀로 이동(추가적인 비디오 로드)
+        isTeleport = false
+        response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: request.curCell)
+        prevCell = request.curCell
+        presenter?.presentMoveCellNext(with: response)
+    }
+
+    func playTeleportVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request) {
+        guard let isTeleport else { return }
+        guard let videos else { return }
+        if isTeleport {
+            if request.indexPathRow == 1 || request.indexPathRow == (videos.count - 2) {
+                let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: request.curCell)
+                prevCell = request.curCell
+                presenter?.presentMoveCellNext(with: response)
+                self.isTeleport = false
+            }
+        }
+    }
+
+    func leavePlaybackView() {
+        let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: nil)
+        presenter?.presentLeavePlaybackView(with: response)
+    }
+
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
@@ -6,83 +6,83 @@
 //  Copyright © 2023 CodeBomber. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 enum PlaybackModels {
+    // MARK: - Properties Type
+    struct PlaybackVideo: Hashable {
+        var id: UUID = UUID()
+        let post: Post
+    }
 
-    // MARK: - Use Cases
+    enum ParentView {
+        case home
+        case other
+    }
 
-    enum FetchFromLocalDataStore {
+    // MARK: - UseCase Load Video List
+
+    enum LoadPlaybackVideoList {
         struct Request {
+
         }
 
         struct Response {
+            let videos: [PlaybackVideo]
         }
 
         struct ViewModel {
-            var exampleTranslation: String?
+            let videos: [PlaybackVideo]
         }
     }
 
-    enum FetchFromRemoteDataStore {
+    // MARK: - UseCase Set Init Playback Scene
+
+    enum SetInitialPlaybackCell {
         struct Request {
+            let indexPathRow: Int
         }
 
         struct Response {
-            var exampleVariable: String?
+            let indexPathRow: Int
         }
 
         struct ViewModel {
-            var exampleVariable: String?
+            let indexPathRow: Int
         }
     }
 
-    enum TrackAnalytics {
+    // MARK: - UseCase Playback Video
+
+    enum DisplayPlaybackVideo {
         struct Request {
-            var event: AnalyticsEvents
+            let indexPathRow: Int?
+            let curCell: PlaybackCell?
         }
 
         struct Response {
+            let indexPathRow: Int?
+            let prevCell: PlaybackCell?
+            let curCell: PlaybackCell?
+
+            init(indexPathRow: Int? = nil, prevCell: PlaybackCell?, curCell: PlaybackCell?) {
+                self.indexPathRow = indexPathRow
+                self.prevCell = prevCell
+                self.curCell = curCell
+            }
         }
 
         struct ViewModel {
+            let indexPathRow: Int?
+            let prevCell: PlaybackCell?
+            let curCell: PlaybackCell?
+
+            init(indexPathRow: Int? = nil, prevCell: PlaybackCell?, curCell: PlaybackCell?) {
+                self.indexPathRow = indexPathRow
+                self.prevCell = prevCell
+                self.curCell = curCell
+            }
         }
     }
 
-    enum PerformPlayback {
-        struct Request {
-            var exampleVariable: String?
-        }
-
-        struct Response {
-            var error: PlaybackError?
-        }
-
-        struct ViewModel {
-            var error: PlaybackError?
-        }
-    }
-
-    // MARK: - Types
-
-    // replace with `AnalyticsEvents` with `AnalyticsConstants` if needed
-    typealias AnalyticsEvents = ExampleAnalyticsEvents
-    typealias PlaybackError = Error<PlaybackErrorType>
-
-    enum ExampleAnalyticsEvents {
-        case screenView
-    }
-
-    enum PlaybackErrorType {
-        case emptyExampleVariable, networkError
-    }
-
-    struct Error<T> {
-        var type: T
-        var message: String?
-
-        init(type: T) {
-            self.type = type
-        }
-    }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
@@ -9,58 +9,77 @@
 import UIKit
 
 protocol PlaybackPresentationLogic {
-    func presentFetchFromLocalDataStore(with response: PlaybackModels.FetchFromLocalDataStore.Response)
-    func presentFetchFromRemoteDataStore(with response: PlaybackModels.FetchFromRemoteDataStore.Response)
-    func presentTrackAnalytics(with response: PlaybackModels.TrackAnalytics.Response)
-    func presentPerformPlayback(with response: PlaybackModels.PerformPlayback.Response)
+    func presentVideoList(with response: PlaybackModels.LoadPlaybackVideoList.Response)
+    func presentSetCellIfInfinite()
+    func presentMoveCellNext(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentSetInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response)
+    func presentMoveInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response)
+    func presentPlayInitialPlaybackCell(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentHidePlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentShowPlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentTeleportCell(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentLeavePlaybackView(with response: PlaybackModels.DisplayPlaybackVideo.Response)
 }
 
-class PlaybackPresenter: PlaybackPresentationLogic {
+final class PlaybackPresenter: PlaybackPresentationLogic {
 
     // MARK: - Properties
 
     typealias Models = PlaybackModels
     weak var viewController: PlaybackDisplayLogic?
 
-    // MARK: - Use Case - Fetch From Local DataStore
+    // MARK: - UseCase Load Video List
 
-    func presentFetchFromLocalDataStore(with response: PlaybackModels.FetchFromLocalDataStore.Response) {
-        let translation = "Some localized text."
-        let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
-        viewController?.displayFetchFromLocalDataStore(with: viewModel)
+    func presentVideoList(with response: PlaybackModels.LoadPlaybackVideoList.Response) {
+        let viewModel: Models.LoadPlaybackVideoList.ViewModel = Models.LoadPlaybackVideoList.ViewModel(videos: response.videos)
+        viewController?.displayVideoList(viewModel: viewModel)
     }
 
-    // MARK: - Use Case - Fetch From Remote DataStore
-
-    func presentFetchFromRemoteDataStore(with response: PlaybackModels.FetchFromRemoteDataStore.Response) {
-        let formattedExampleVariable = response.exampleVariable ?? ""
-        let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: formattedExampleVariable)
-        viewController?.displayFetchFromRemoteDataStore(with: viewModel)
+    func presentSetCellIfInfinite() {
+        viewController?.displayMoveCellIfinfinite()
     }
 
-    // MARK: - Use Case - Track Analytics
+    // MARK: - UseCase Set Init Playback Scene
 
-    func presentTrackAnalytics(with response: PlaybackModels.TrackAnalytics.Response) {
-        let viewModel = Models.TrackAnalytics.ViewModel()
-        viewController?.displayTrackAnalytics(with: viewModel)
+    func presentSetInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response) {
+        let viewModel: Models.SetInitialPlaybackCell.ViewModel = Models.SetInitialPlaybackCell.ViewModel(indexPathRow: response.indexPathRow)
+        viewController?.setInitialPlaybackCell(viewModel: viewModel)
     }
 
-    // MARK: - Use Case - Playback
+    func presentMoveInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response) {
+        let viewModel: Models.SetInitialPlaybackCell.ViewModel = Models.SetInitialPlaybackCell.ViewModel(indexPathRow: response.indexPathRow)
+        viewController?.moveInitialPlaybackCell(viewModel: viewModel)
+    }
 
-    func presentPerformPlayback(with response: PlaybackModels.PerformPlayback.Response) {
-        var responseError = response.error
+    // MARK: - UseCase Playback Video
 
-        if let error = responseError {
-            switch error.type {
-            case .emptyExampleVariable:
-                responseError?.message = "Localized empty/nil error message."
+    func presentMoveCellNext(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: response.prevCell, curCell: response.curCell)
+        viewController?.stopPrevPlayerAndPlayCurPlayer(viewModel: viewModel)
+    }
 
-            case .networkError:
-                responseError?.message = "Localized network error message."
-            }
-        }
+    func presentPlayInitialPlaybackCell(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: nil, curCell: response.curCell)
+        viewController?.stopPrevPlayerAndPlayCurPlayer(viewModel: viewModel)
+    }
 
-        let viewModel = Models.PerformPlayback.ViewModel(error: responseError)
-        viewController?.displayPerformPlayback(with: viewModel)
+    func presentHidePlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: response.prevCell, curCell: nil)
+        viewController?.hidePlayerSlider(viewModel: viewModel)
+    }
+
+    func presentShowPlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: nil, curCell: response.curCell)
+        viewController?.showPlayerSlider(viewModel: viewModel)
+    }
+
+    func presentTeleportCell(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(indexPathRow: response.indexPathRow, prevCell: nil, curCell: nil)
+        viewController?.teleportPlaybackCell(viewModel: viewModel)
+    }
+
+    func presentLeavePlaybackView(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
+        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: response.prevCell, curCell: nil)
+        viewController?.leavePlaybackView(viewModel: viewModel)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackRouter.swift
@@ -16,7 +16,7 @@ protocol PlaybackDataPassing {
     var dataStore: PlaybackDataStore? { get }
 }
 
-class PlaybackRouter: NSObject, PlaybackRoutingLogic, PlaybackDataPassing {
+final class PlaybackRouter: NSObject, PlaybackRoutingLogic, PlaybackDataPassing {
 
     // MARK: - Properties
 
@@ -26,15 +26,6 @@ class PlaybackRouter: NSObject, PlaybackRoutingLogic, PlaybackDataPassing {
     // MARK: - Routing
 
     func routeToNext() {
-        // let destinationVC = UIStoryboard(name: "", bundle: nil).instantiateViewController(withIdentifier: "") as! NextViewController
-        // var destinationDS = destinationVC.router!.dataStore!
-        // passDataTo(destinationDS, from: dataStore!)
-        // viewController?.navigationController?.pushViewController(destinationVC, animated: true)
+        
     }
-
-    // MARK: - Data Passing
-
-    // func passDataTo(_ destinationDS: inout NextDataStore, from sourceDS: PlaybackDataStore) {
-    //     destinationDS.attribute = sourceDS.attribute
-    // }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class PlaybackWorker {
+final class PlaybackWorker {
 
     // MARK: - Properties
 
@@ -16,17 +16,14 @@ class PlaybackWorker {
 
     // MARK: - Methods
 
-    // MARK: Screen Specific Validation
-
-    func validate(exampleVariable: String?) -> Models.PlaybackError? {
-        var error: Models.PlaybackError?
-
-        if exampleVariable?.isEmpty == false {
-            error = nil
-        } else {
-            error = Models.PlaybackError(type: .emptyExampleVariable)
-        }
-
-        return error
+    func makeInfiniteScroll(videos: [Models.PlaybackVideo]) -> [Models.PlaybackVideo] {
+        var tempVideos: [Models.PlaybackVideo] = videos
+        var tempLastVideo: Models.PlaybackVideo = videos[tempVideos.count-1]
+        tempLastVideo.id = UUID()
+        var tempFirstVideo: Models.PlaybackVideo = videos[1]
+        tempFirstVideo.id = UUID()
+        tempVideos.insert(tempLastVideo, at: 0)
+        tempVideos.append(tempFirstVideo)
+        return tempVideos
     }
 }

--- a/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/LoopingPlayerView.swift
@@ -32,7 +32,7 @@ final class LoopingPlayerView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        playerLayer?.frame = bounds
+        playerLayer?.bounds = bounds
         playerLayer?.videoGravity = .resizeAspectFill
     }
 

--- a/iOS/Layover/Layover/Services/System.swift
+++ b/iOS/Layover/Layover/Services/System.swift
@@ -1,0 +1,22 @@
+//
+//  System.swift
+//  Layover
+//
+//  Created by 김인환 on 12/1/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+enum System {
+
+    @UserDefaultStored(key: UserDefaultKey.hasBeenLaunchedBefore, defaultValue: false) static var hasBeenLaunchedBefore: Bool
+
+    static func isFirstLaunch() -> Bool {
+        if !hasBeenLaunchedBefore {
+            hasBeenLaunchedBefore = true
+            return true
+        }
+        return false
+    }
+}

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -30,4 +30,5 @@ struct UserDefaultStored<T> {
 
 enum UserDefaultKey {
     static let isLoggedIn = "isLoggedIn"
+    static let hasBeenLaunchedBefore = "hasBeenLaunchedBefore"
 }

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -14,8 +14,6 @@ final class MockUserWorker: UserWorkerProtocol {
     // MARK: - Properties
 
     private let provider: ProviderType = Provider(session: .initMockSession())
-    private let headers: [String: String] = ["Content-Type": "application/json",
-                                             "Authorization": "mock token"]
 
     // MARK: - Methods
 
@@ -43,8 +41,7 @@ final class MockUserWorker: UserWorkerProtocol {
             }
             let endPoint: EndPoint = EndPoint<Response<NicknameDTO>>(path: "/member/username",
                                                                      method: .PATCH,
-                                                                     bodyParameters: NicknameDTO(userName: nickname),
-                                                                     headers: headers)
+                                                                     bodyParameters: NicknameDTO(userName: nickname))
             let response = try await provider.request(with: endPoint)
             guard let data = response.data else { return nil }
             return data.userName
@@ -68,9 +65,8 @@ final class MockUserWorker: UserWorkerProtocol {
             }
             let endPoint = EndPoint<Response<CheckUserNameDTO>>(path: "/member/check-username",
                                                                 method: .POST,
-                                                                bodyParameters: NicknameDTO(userName: userName),
-                                                                headers: headers)
-            let response = try await provider.request(with: endPoint)
+                                                                bodyParameters: NicknameDTO(userName: userName))
+            let response = try await provider.request(with: endPoint, authenticationIfNeeded: false)
             guard let data = response.data else { throw NetworkError.emptyData }
             return data.isValid
         } catch {
@@ -95,8 +91,7 @@ final class MockUserWorker: UserWorkerProtocol {
 
             let endPoint = EndPoint<Response<IntroduceDTO>>(path: "/member/introduce",
                                                             method: .PATCH,
-                                                            bodyParameters: IntroduceDTO(introduce: introduce),
-                                                            headers: headers)
+                                                            bodyParameters: IntroduceDTO(introduce: introduce))
             let response = try await provider.request(with: endPoint)
             guard let data = response.data else { return nil }
             return data.introduce
@@ -119,8 +114,7 @@ final class MockUserWorker: UserWorkerProtocol {
                 return (response, mockData, nil)
             }
             let endPoint = EndPoint<Response<NicknameDTO>>(path: "/member",
-                                                           method: .DELETE,
-                                                           headers: ["Authorization": "mock token"])
+                                                           method: .DELETE)
             let response = try await provider.request(with: endPoint)
             guard let data = response.data else { throw NetworkError.emptyData }
             return data.userName

--- a/iOS/Layover/Layover/Workers/VideoFileWorker.swift
+++ b/iOS/Layover/Layover/Workers/VideoFileWorker.swift
@@ -1,0 +1,66 @@
+//
+//  VideoFileWorker.swift
+//  Layover
+//
+//  Created by kong on 2023/11/30.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+import OSLog
+
+protocol VideoFileWorkerProtocol {
+    func copyToNewURL(at videoURL: URL) -> URL?
+    func delete(at videoURL: URL) -> Bool
+}
+
+final class VideoFileWorker: VideoFileWorkerProtocol {
+
+    // MARK: - Properties
+
+    private let fileManager: FileManager
+    private let directoryPath: String
+    private let fileName: String
+
+    // MARK: - Intializer
+
+    init(fileManager: FileManager = FileManager.default,
+         directoryPath: String = "layover",
+         fileName: String = "\(Int(Date().timeIntervalSince1970))") {
+        self.fileManager = fileManager
+        self.directoryPath = directoryPath
+        self.fileName = fileName
+
+    }
+
+    // MARK: - Methods
+
+    func copyToNewURL(at videoURL: URL) -> URL? {
+        let temporaryDirectory = fileManager.temporaryDirectory
+        let path = "\(directoryPath)/\(fileName).\(videoURL.pathExtension)"
+
+        let newURL = temporaryDirectory.appending(path: path)
+        do {
+            if fileManager.fileExists(atPath: newURL.path()) {
+                delete(at: newURL)
+            }
+            try fileManager.createDirectory(at: temporaryDirectory.appending(path: directoryPath),
+                                            withIntermediateDirectories: true)
+            try fileManager.copyItem(at: videoURL as URL, to: newURL)
+            return newURL
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
+    }
+
+    @discardableResult
+    func delete(at videoURL: URL) -> Bool {
+        do {
+            try fileManager.removeItem(at: videoURL)
+            return true
+        } catch {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- [x] 재생화면의 VIP 싸이클 적용
- [x] 홈화면과 그 외 화면들 무한 스크롤 다르게 적용
- [x] MemberDTO와 VideoDTO 생성

![스크린샷 2023-11-30 오전 10 47 56](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/452ba86a-683f-4efc-874e-fc9ba424a846)

![스크린샷 2023-11-30 오전 10 53 03](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/15e000e4-40d2-4b8e-a27b-a1aa653243f7)

![스크린샷 2023-11-30 오전 11 08 57](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/5b1cd5dc-362b-4215-97ef-27cfc35ca2c0)

![스크린샷 2023-11-30 오전 11 17 09](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/386fd91a-ae02-428c-9e86-12c020753713)

보충 설명을 하자면 VC에서는 presenter로 전달받은 viewModel의 값들을 stopPlayer를 통해 멈추고 playPlayer를 통해 실행시키거나 합니다. playbackCollectionView의 setContentOff를 통해 viewModel값에 있는 indexPath만큼 이동시키거나 합니다.

#### 📌 변경 사항
홈화면과 지도화면에서 재생화면으로 넘어온다고 각 Scene의 코드를 건드린 부분이 있습니다.
잘못건드렸거나 의도에 맞지 않게 수정되었다면 얘기해주시면 얼른 고치겠습니다.
그리고 홈화면과 그 외 화면들 무한 스크롤 방식 차이에 대해서 이야기 하고 싶습니다.
홈화면의 경우 아래로 이동(위로 스와이프) 시 비디오를 로드하는 동작만 넣고 처음 셀로는 이동 안하면 UX적으로 좋을 것 같습니다. 새로고침 하는 느낌?

그 외 화면들은 목록 다 불러와 놓고 한바퀴 도는 형식이 되겠네요

##### 📸 ScreenShot

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/d3309ac4-91d2-42b8-8c8c-10eeea8ea33a

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/7e746e8d-2821-4fb2-be3c-965e2eb66593


#### Linked Issue
close #122 
