### PR TITLE
feat: 네비게이션 바 back button 이미지 설정

### DIFF
--- a/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
@@ -31,6 +31,13 @@ final class MainTabBarConfigurator: Configurator {
         profileViewController.tabBarItem = UITabBarItem(title: "프로필",
                                                         image: profileIconImage.withTintColor(.white),
                                                         selectedImage: nil)
+
+        [homeViewController, mapViewController, profileViewController].forEach {
+            $0.navigationBar.topItem?.backBarButtonItem = UIBarButtonItem(customView: UIImageView(image: .iconTabBack))
+            $0.navigationBar.backIndicatorImage = UIImage.iconTabBack
+            $0.navigationBar.backIndicatorTransitionMaskImage = UIImage.iconTabBack
+        }
+
         viewController.navigationController?.setNavigationBarHidden(true, animated: false)
         viewController.setViewControllers([
             homeViewController,


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
네비게이션 바 back button 이미지를 설정했습니다.

#### 📌 변경 사항
MainTabBarConfiguration에서 각 탭의 navigationController에 설정해 두었기 때문에 
푸시된 viewController의 backButton에 대해 신경쓰지 않으셔도 됩니다:)

##### 📸 ScreenShot
<img src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/55f3d8c5-d0d2-4dfd-b1df-92e6f55ead67" width=40%>

#### Linked Issue
close #155 
