### PR TITLE
chore: 재생화면 동작 개선

### DIFF
--- a/iOS/Layover/Layover/DesignSystem/LOSlider.swift
+++ b/iOS/Layover/Layover/DesignSystem/LOSlider.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class LOSlider: UISlider {
     static let loSliderHeight: CGFloat = 10
+    var playerView: PlayerView?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -34,5 +35,9 @@ final class LOSlider: UISlider {
         setThumbImage(UIImage.loNormalThumb, for: .normal)
         self.minimumValue = 0
         self.maximumValue = 1
+    }
+
+    func setPlayerView(_ newPlayerView: PlayerView) {
+        playerView = newPlayerView
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -31,11 +31,6 @@ final class PlaybackCell: UICollectionViewCell {
         playbackView.addAVPlayer(url: url)
     }
 
-    func setPlayerSlider(tabbarHeight: CGFloat) {
-        playbackView.setPlayerSlider()
-        playbackView.setPlayerSliderUI(tabbarHeight: tabbarHeight)
-    }
-
     private func configure() {
         playbackView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(playbackView)
@@ -45,6 +40,5 @@ final class PlaybackCell: UICollectionViewCell {
             playbackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             playbackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
-        playbackView.playerSlider.isHidden = true
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -21,11 +21,9 @@ final class PlaybackCell: UICollectionViewCell {
         configure()
     }
 
-    // TODO: VideoModel 받아서 처리
-    func setPlaybackContents(viewModel: PlaybackModels.PlaybackVideo) {
-        playbackView.descriptionView.titleLabel.text = viewModel.post.board.title
-        playbackView.descriptionView.setText(viewModel.post.board.description ?? "")
-
+    func setPlaybackContents(video: Post) {
+        playbackView.descriptionView.titleLabel.text = video.board.title
+        playbackView.descriptionView.setText(video.board.description ?? "")
     }
 
     func addAVPlayer(url: URL) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
@@ -11,7 +11,6 @@ import UIKit
 protocol PlaybackBusinessLogic {
     func displayVideoList()
     func moveInitialPlaybackCell()
-    func hidePlayerSlider()
     func setInitialPlaybackCell()
     func leavePlaybackView()
     func playInitialPlaybackCell(with request: PlaybackModels.DisplayPlaybackVideo.Request)
@@ -92,11 +91,6 @@ final class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
         prevCell = request.curCell
         let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: nil, curCell: request.curCell)
         presenter?.presentPlayInitialPlaybackCell(with: response)
-    }
-
-    func hidePlayerSlider() {
-        let response: Models.DisplayPlaybackVideo.Response = Models.DisplayPlaybackVideo.Response(prevCell: prevCell, curCell: nil)
-        presenter?.presentHidePlayerSlider(with: response)
     }
 
     func playVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
@@ -17,6 +17,7 @@ protocol PlaybackBusinessLogic {
     func playInitialPlaybackCell(with request: PlaybackModels.DisplayPlaybackVideo.Request)
     func playVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request)
     func playTeleportVideo(with request: PlaybackModels.DisplayPlaybackVideo.Request)
+    func configurePlaybackCell()
 }
 
 protocol PlaybackDataStore: AnyObject {
@@ -62,7 +63,6 @@ final class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
         let response: Models.LoadPlaybackVideoList.Response = Models.LoadPlaybackVideoList.Response(videos: videos)
         presenter?.presentVideoList(with: response)
     }
-
 
     func moveInitialPlaybackCell() {
         let response: Models.SetInitialPlaybackCell.Response = Models.SetInitialPlaybackCell.Response(indexPathRow: index ?? 0)
@@ -150,4 +150,16 @@ final class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
         presenter?.presentLeavePlaybackView(with: response)
     }
 
+    func configurePlaybackCell() {
+        guard let videos else { return }
+        guard let parentView else { return }
+        let response: Models.ConfigurePlaybackCell.Response
+        switch parentView {
+        case .home:
+            response = Models.ConfigurePlaybackCell.Response(teleportIndex: nil)
+        case .other:
+            response = Models.ConfigurePlaybackCell.Response(teleportIndex: videos.count + 1)
+        }
+        presenter?.presentConfigureCell(with: response)
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
@@ -85,4 +85,18 @@ enum PlaybackModels {
         }
     }
 
+    // MARK: - UseCase Cell Configure
+
+    enum ConfigurePlaybackCell {
+        struct Request {
+        }
+
+        struct Response {
+            let teleportIndex: Int?
+        }
+
+        struct ViewModel {
+            let teleportIndex: Int?
+        }
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
@@ -15,7 +15,6 @@ protocol PlaybackPresentationLogic {
     func presentSetInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response)
     func presentMoveInitialPlaybackCell(with response: PlaybackModels.SetInitialPlaybackCell.Response)
     func presentPlayInitialPlaybackCell(with response: PlaybackModels.DisplayPlaybackVideo.Response)
-    func presentHidePlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response)
     func presentShowPlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response)
     func presentTeleportCell(with response: PlaybackModels.DisplayPlaybackVideo.Response)
     func presentLeavePlaybackView(with response: PlaybackModels.DisplayPlaybackVideo.Response)
@@ -62,11 +61,6 @@ final class PlaybackPresenter: PlaybackPresentationLogic {
     func presentPlayInitialPlaybackCell(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
         let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: nil, curCell: response.curCell)
         viewController?.stopPrevPlayerAndPlayCurPlayer(viewModel: viewModel)
-    }
-
-    func presentHidePlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
-        let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: response.prevCell, curCell: nil)
-        viewController?.hidePlayerSlider(viewModel: viewModel)
     }
 
     func presentShowPlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
@@ -19,6 +19,7 @@ protocol PlaybackPresentationLogic {
     func presentShowPlayerSlider(with response: PlaybackModels.DisplayPlaybackVideo.Response)
     func presentTeleportCell(with response: PlaybackModels.DisplayPlaybackVideo.Response)
     func presentLeavePlaybackView(with response: PlaybackModels.DisplayPlaybackVideo.Response)
+    func presentConfigureCell(with response: PlaybackModels.ConfigurePlaybackCell.Response)
 }
 
 final class PlaybackPresenter: PlaybackPresentationLogic {
@@ -81,5 +82,10 @@ final class PlaybackPresenter: PlaybackPresentationLogic {
     func presentLeavePlaybackView(with response: PlaybackModels.DisplayPlaybackVideo.Response) {
         let viewModel: Models.DisplayPlaybackVideo.ViewModel = Models.DisplayPlaybackVideo.ViewModel(prevCell: response.prevCell, curCell: nil)
         viewController?.leavePlaybackView(viewModel: viewModel)
+    }
+
+    func presentConfigureCell(with response: PlaybackModels.ConfigurePlaybackCell.Response) {
+        let viewModel: Models.ConfigurePlaybackCell.ViewModel = Models.ConfigurePlaybackCell.ViewModel(teleportIndex: response.teleportIndex)
+        viewController?.configureDataSource(viewModel: viewModel)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackRouter.swift
@@ -26,6 +26,6 @@ final class PlaybackRouter: NSObject, PlaybackRoutingLogic, PlaybackDataPassing 
     // MARK: - Routing
 
     func routeToNext() {
-        
+
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
@@ -41,7 +41,6 @@ final class PlaybackView: UIView {
         button.layer.cornerRadius = 19
         button.layer.borderWidth = 1
         button.layer.borderColor = UIColor.layoverWhite.cgColor
-//        button.setImage(UIImage(systemName: "cancel"), for: .normal)
         button.backgroundColor = .layoverWhite
         return button
     }()
@@ -78,8 +77,6 @@ final class PlaybackView: UIView {
         return imageView
     }()
 
-    let playerSlider: LOSlider = LOSlider()
-
     let playerView: PlayerView = PlayerView()
 
     // MARK: - View Life Cycle
@@ -90,7 +87,6 @@ final class PlaybackView: UIView {
         addDescriptionAnimateGesture()
         setSubViewsInPlayerViewConstraints()
         setPlayerView()
-        setPlayerSlider()
     }
 
     required init?(coder: NSCoder) {
@@ -99,7 +95,6 @@ final class PlaybackView: UIView {
         addDescriptionAnimateGesture()
         setSubViewsInPlayerViewConstraints()
         setPlayerView()
-        setPlayerSlider()
     }
 
     // MARK: Player Setting Method
@@ -110,32 +105,6 @@ final class PlaybackView: UIView {
 
     func getPlayerItemStatus() -> AVPlayerItem.Status? {
         playerView.player?.currentItem?.status
-    }
-
-    func setPlayerSlider() {
-        let interval: CMTime = CMTimeMakeWithSeconds(1, preferredTimescale: Int32(NSEC_PER_SEC))
-        playerView.player?.addPeriodicTimeObserver(forInterval: interval, queue: .main, using: { [weak self] currentTime in
-            self?.updateSlider(currentTime: currentTime)
-        })
-        playerSlider.addTarget(self, action: #selector(didChangedSliderValue(_:)), for: .valueChanged)
-    }
-
-    func setPlayerSliderUI(tabbarHeight: CGFloat) {
-        let scenes = UIApplication.shared.connectedScenes
-        let windowScene = scenes.first as? UIWindowScene
-        let window = windowScene?.windows.first
-        guard let playerSliderWidth: CGFloat = windowScene?.screen.bounds.width else {
-            return
-        }
-        guard let windowHeight = (windowScene?.screen.bounds.height) else {
-            return
-        }
-        playerSlider.frame = CGRect(x: 0,
-                                    y: (windowHeight - tabbarHeight - LOSlider.loSliderHeight),
-                                    width: playerSliderWidth,
-                                    height: LOSlider.loSliderHeight)
-        window?.addSubview(playerSlider)
-        playerSlider.window?.windowLevel = UIWindow.Level.normal + 1
     }
 
     // MARK: Player Play Method
@@ -161,14 +130,6 @@ final class PlaybackView: UIView {
 
 private extension PlaybackView {
     func updateSlider(currentTime: CMTime) {
-        guard let currentItem: AVPlayerItem = playerView.player?.currentItem else {
-            return
-        }
-        let duration: CMTime = currentItem.duration
-        if CMTIME_IS_INVALID(duration) {
-            return
-        }
-        playerSlider.value = Float(CMTimeGetSeconds(currentTime) / CMTimeGetSeconds(duration))
     }
 
     // MARK: - Gesture Method
@@ -255,7 +216,7 @@ private extension PlaybackView {
                 let size = CGSize(width: LODescriptionView.descriptionWidth, height: .infinity)
                 let estimatedSize = descriptionView.descriptionLabel.sizeThatFits(size)
                 let totalHeight: CGFloat = estimatedSize.height + descriptionView.titleLabel.intrinsicContentSize.height
-                UIView.animate(withDuration: 0.3,animations: {
+                UIView.animate(withDuration: 0.3, animations: {
                     self.descriptionView.titleLabel.transform = CGAffineTransform(translationX: 0, y: -(totalHeight - LODescriptionView.descriptionHeight))
                     self.descriptionView.descriptionLabel.transform = CGAffineTransform(translationX: 0, y: -(totalHeight - LODescriptionView.descriptionHeight))
                     self.gradientLayer.isHidden = true
@@ -297,16 +258,6 @@ private extension PlaybackView {
 
     @objc func playerDidFinishPlaying(note: NSNotification) {
         playerView.seek(to: CMTime.zero)
-        playerView.play()
-    }
-
-    @objc func didChangedSliderValue(_ sender: LOSlider) {
-        guard let duration: CMTime = playerView.player?.currentItem?.duration else {
-            return
-        }
-        let value: Float64 = Float64(sender.value) * CMTimeGetSeconds(duration)
-        let seekTime: CMTime = CMTime(value: CMTimeValue(value), timescale: 1)
-        playerView.seek(to: seekTime)
         playerView.play()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
@@ -183,7 +183,7 @@ private extension PlaybackView {
         let descriptionViewGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(descriptionViewDidTap(_:)))
         descriptionView.descriptionLabel.addGestureRecognizer(descriptionViewGesture)
     }
-    
+
     // MARK: - UI Method
 
     func setDescriptionViewUI() {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -21,6 +21,7 @@ protocol PlaybackDisplayLogic: AnyObject {
     func showPlayerSlider(viewModel: PlaybackModels.DisplayPlaybackVideo.ViewModel)
     func teleportPlaybackCell(viewModel: PlaybackModels.DisplayPlaybackVideo.ViewModel)
     func leavePlaybackView(viewModel: PlaybackModels.DisplayPlaybackVideo.ViewModel)
+    func configureDataSource(viewModel: PlaybackModels.ConfigurePlaybackCell.ViewModel)
 }
 
 final class PlaybackViewController: BaseViewController {
@@ -70,7 +71,8 @@ final class PlaybackViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureDataSource()
+//        configureDataSource()
+        interactor?.configurePlaybackCell()
         interactor?.displayVideoList()
         playbackCollectionView.delegate = self
         playbackCollectionView.contentInsetAdjustmentBehavior = .never
@@ -180,20 +182,21 @@ extension PlaybackViewController: PlaybackDisplayLogic {
         viewModel.prevCell?.playbackView.playerSlider.isHidden = true
         viewModel.prevCell?.playbackView.stopPlayer()
     }
-}
 
-// MARK: - Playback Method
-
-private extension PlaybackViewController {
-    func configureDataSource() {
+    func configureDataSource(viewModel: PlaybackModels.ConfigurePlaybackCell.ViewModel) {
         guard let tabbarHeight: CGFloat = self.tabBarController?.tabBar.frame.height else {
             return
         }
         playbackCollectionView.register(PlaybackCell.self, forCellWithReuseIdentifier: PlaybackCell.identifier)
         dataSource = UICollectionViewDiffableDataSource<Section, Models.PlaybackVideo>(collectionView: playbackCollectionView) { (collectionView, indexPath, video) -> UICollectionViewCell? in
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaybackCell.identifier, for: indexPath) as? PlaybackCell else { return PlaybackCell() }
+            cell.setPlaybackContents(video: video.post)
+            if let teleportIndex = viewModel.teleportIndex {
+                if indexPath.row == 0 || indexPath.row == viewModel.teleportIndex {
+                    return cell
+                }
+            }
             guard let videoURL: URL = video.post.board.videoURL else { return PlaybackCell()}
-            cell.setPlaybackContents(viewModel: video)
             cell.addAVPlayer(url: videoURL)
             cell.setPlayerSlider(tabbarHeight: tabbarHeight)
             return cell

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 import AVFoundation
 
+import OSLog
+
 protocol PlaybackDisplayLogic: AnyObject {
     func displayVideoList(viewModel: PlaybackModels.LoadPlaybackVideoList.ViewModel)
     func displayMoveCellIfinfinite()
@@ -75,7 +77,7 @@ final class PlaybackViewController: BaseViewController {
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
         } catch {
-            print("Setting category to AVAudioSessionCategoryPlayback failed.")
+            os_log("Setting category to AVAudioSessionCategoryPlayback failed.")
         }
     }
 
@@ -97,6 +99,7 @@ final class PlaybackViewController: BaseViewController {
     // MARK: - UI + Layout
 
     override func setConstraints() {
+        super.setConstraints()
         playbackCollectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(playbackCollectionView)
         NSLayoutConstraint.activate([
@@ -107,6 +110,16 @@ final class PlaybackViewController: BaseViewController {
         ])
     }
 
+    override func setUI() {
+        super.setUI()
+        self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationController?.navigationBar.shadowImage = UIImage()
+        self.navigationController?.navigationBar.isTranslucent = true
+
+        self.tabBarController?.tabBar.backgroundImage = UIImage()
+        self.tabBarController?.tabBar.shadowImage = UIImage()
+        self.tabBarController?.tabBar.clipsToBounds = true
+    }
 }
 
 extension PlaybackViewController: PlaybackDisplayLogic {


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- [x] collectionView cell 사이에 생기는 여백 파악하기
- [x] 수정하기
- [x] 셀이 내비바에도 보이도록 하기
- [x] 무한스크롤 시 텔레포트를 위한 셀은 그냥 동영상 로드 안 해버리기
- [x] Slider cell에서 collectionView로 빼기

#### 📌 변경 사항
변경 사항은 아닙니다만.
원래 HomeView, MapView에서 넘어올 때 collectionView Delegate로 빼려 했는데(select did item) Home View나 Map View 따로 작업하실 것 같아 뒤로 미루겠습니다.

##### 📸 ScreenShot

|제목|내용|
|------|-----|
|![Simulator Screenshot - iPhone 13 mini - 2023-12-02 at 14 45 21](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/f72c020d-872a-4972-b09b-cc662c4e13a6)|![Simulator Screenshot - iPhone 13 mini - 2023-12-02 at 20 03 22](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/13684823-9f85-49a1-bc79-a92648e81f4a)|

UIVisualEffectBackdropView라고 NavigationBar와 TabBar에 뿌옇게 효과가 생겨 해당 부분을 투명하게 만들어 주었습니다.
텔레포트를 위해 더미 셀을 만드는데, 더미 셀에도 동영상 로드를 하고 있어 좀 느린 것 같아 해당 부분은 동영상 로드 안하고 넘어갈 수 있도록 했습니다.

|제목|내용|
|------|-----|
|![스크린샷 2023-12-02 오후 8 09 25](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/ebfea0ab-044c-42cc-9fba-f607e1af46b8)|![스크린샷 2023-12-02 오후 8 09 45](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/ff529a9a-e565-4ab1-bc33-d0502bc3cb77)|

기존에는 cell마다 LOSlider가 들어가 셀이 늘어날 수록 Slider가 중첩돼서 생겼는데, 이 문제를 해결하고자 Slider를 CollectionView에서 하나만 쓸 수 있도록 했습니다.

#### Linked Issue
close #163
