### PR TITLE
chore: Toast UI 수정

### DIFF
--- a/iOS/Layover/Layover/Scenes/UIComponents/Toast.swift
+++ b/iOS/Layover/Layover/Scenes/UIComponents/Toast.swift
@@ -8,6 +8,28 @@
 
 import UIKit
 
+final class ToastLabel: UILabel {
+    private let topInset: CGFloat = 14
+    private let bottomInset: CGFloat = 14
+    private let leftInset: CGFloat = 25
+    private let rightInset: CGFloat = 25
+
+    override func drawText(in rect: CGRect) {
+        let insets = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + leftInset + rightInset, height: size.height + topInset + bottomInset)
+    }
+
+    override var bounds: CGRect {
+        didSet { preferredMaxLayoutWidth = bounds.width - (leftInset + rightInset) }
+    }
+
+}
+
 final class Toast {
     static let shared = Toast()
 
@@ -17,7 +39,7 @@ final class Toast {
         let scenes: Set<UIScene> = UIApplication.shared.connectedScenes
         let windowScene: UIWindowScene? = scenes.first as? UIWindowScene
         guard let window: UIWindow = windowScene?.windows.first else { return }
-        let toastLabel: UILabel = UILabel()
+        let toastLabel: ToastLabel = ToastLabel()
         toastLabel.backgroundColor = .background
         toastLabel.textColor = .layoverWhite
         toastLabel.textAlignment = .center


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
Toast 띄울 때 나오는 Label 여백을 늘렸습니다.

#### 📌 변경 사항

##### 📸 ScreenShot

![IMG_7D6F61D32DE6-1](https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/27155f01-050f-45d7-9801-3a0b350c50d1)


#### Linked Issue
close #158 
