### PR TITLE
chore: navigationBar, tabBar appearance 관련 설정 수정

### DIFF
--- a/iOS/Layover/Layover/AppDelegate.swift
+++ b/iOS/Layover/Layover/AppDelegate.swift
@@ -23,6 +23,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // kakao
         guard let KAKAO_APP_KEY = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as? String else { return true }
         KakaoSDK.initSDK(appKey: KAKAO_APP_KEY)
+
+        setNavigationControllerAppearance()
+        setTabBarAppearance()
+
         return true
     }
 
@@ -40,6 +44,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
+    private func setNavigationControllerAppearance() {
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationBarAppearance.configureWithTransparentBackground()
+        navigationBarAppearance.setBackIndicatorImage(UIImage.iconTabBack, transitionMaskImage: UIImage.iconTabBack)
+        UINavigationBar.appearance().standardAppearance = navigationBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
+        UINavigationBar.appearance().compactAppearance = navigationBarAppearance
+    }
 
+    private func setTabBarAppearance() {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithTransparentBackground()
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+    }
 }
 

--- a/iOS/Layover/Layover/Scenes/BaseViewController.swift
+++ b/iOS/Layover/Layover/Scenes/BaseViewController.swift
@@ -33,5 +33,7 @@ class BaseViewController: UIViewController {
     /// Call when ViewDidLoad After setConstraints()
     func setUI() {
         view.backgroundColor = UIColor.background
+        navigationItem.backBarButtonItem = UIBarButtonItem(
+                title: "", style: .plain, target: nil, action: nil)
     }
 }

--- a/iOS/Layover/Layover/Scenes/SettingScene/SettingSceneViewController.swift
+++ b/iOS/Layover/Layover/Scenes/SettingScene/SettingSceneViewController.swift
@@ -75,18 +75,21 @@ final class SettingSceneViewController: BaseViewController {
         ])
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        restoreNavigationBar()
+    }
+
     override func setUI() {
         setNavigationBar()
     }
 
     private func setNavigationBar() {
-        self.navigationController?.navigationBar.tintColor = .layoverWhite
         self.navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationController?.navigationBar.topItem?.title = ""
     }
 
-    @objc func popViewController() {
-        self.navigationController?.popViewController(animated: true)
+    private func restoreNavigationBar() {
+        navigationController?.navigationBar.prefersLargeTitles = false
     }
 }
 

--- a/iOS/Layover/Layover/Scenes/SettingScene/SettingSceneViewController.swift
+++ b/iOS/Layover/Layover/Scenes/SettingScene/SettingSceneViewController.swift
@@ -66,6 +66,7 @@ final class SettingSceneViewController: BaseViewController {
     }
 
     override func setConstraints() {
+        super.setConstraints()
         view.addSubview(settingSceneTableView)
         NSLayoutConstraint.activate([
             settingSceneTableView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -81,11 +82,12 @@ final class SettingSceneViewController: BaseViewController {
     }
 
     override func setUI() {
+        super.setUI()
         setNavigationBar()
     }
 
     private func setNavigationBar() {
-        self.navigationController?.navigationBar.prefersLargeTitles = true
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     private func restoreNavigationBar() {

--- a/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Tabbar/MainTabBarConfigurator.swift
@@ -32,12 +32,6 @@ final class MainTabBarConfigurator: Configurator {
                                                         image: profileIconImage.withTintColor(.white),
                                                         selectedImage: nil)
 
-        [homeViewController, mapViewController, profileViewController].forEach {
-            $0.navigationBar.topItem?.backBarButtonItem = UIBarButtonItem(customView: UIImageView(image: .iconTabBack))
-            $0.navigationBar.backIndicatorImage = UIImage.iconTabBack
-            $0.navigationBar.backIndicatorTransitionMaskImage = UIImage.iconTabBack
-        }
-
         viewController.navigationController?.setNavigationBarHidden(true, animated: false)
         viewController.setViewControllers([
             homeViewController,


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- navigationBar appearance 설정 수정
- tabBar appearance 설정 수정

#### 📌 변경 사항
- AppDelegate와 BaseViewController의 조합으로 appearance를 수정했습니다.
- Global appearance 설정은 AppDelegate에서 하고, 각 화면 별 backButton title은 각 화면에서 설정해야 한다고 하는군요.
- 다행히 우리는 BaseViewController를 통해서 해결할 수 있었네요. BaseViewController 로 빼길 잘한 것 같습니다.
- 이것도 setUI 메서드를 오버라이드 할 경우에, 부모메서드를 꼭 호출해야 합니다.

#### Linked Issue
close #182 
