### PR TITLE
feat: 홈 캐러셀 태그버튼 터치 시 태그 검색 뷰로 전환 구현

### DIFF
--- a/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Home/Cell/HomeCarouselCollectionViewCell.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol HomeCarouselCollectionViewDelegate: AnyObject {
+    func homeCarouselCollectionViewDidTouchedTagButton(_ cell: HomeCarouselCollectionViewCell, tag: String)
+}
+
 final class HomeCarouselCollectionViewCell: UICollectionViewCell {
 
     // MARK: - UI Components
@@ -40,6 +44,8 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     var isPlayingVideos: Bool {
         loopingPlayerView.isPlaying
     }
+
+    weak var delegate: HomeCarouselCollectionViewDelegate?
 
     // MARK: - Object lifecycle
 
@@ -116,6 +122,7 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
             let button = UIButton(configuration: configuration)
             button.clipsToBounds = true
             button.layer.cornerRadius = 12
+            button.addTarget(self, action: #selector(tagButtonDidTap(_:)), for: .touchUpInside)
             tagStackView.addArrangedSubview(button)
         }
         tagStackView.addArrangedSubview(UIView())
@@ -133,5 +140,12 @@ final class HomeCarouselCollectionViewCell: UICollectionViewCell {
     func pauseVideo() {
         thumbnailImageView.isHidden = false
         loopingPlayerView.pause()
+    }
+
+    // MARK: - Actions
+
+    @objc private func tagButtonDidTap(_ sender: UIButton) {
+        guard let tag = sender.titleLabel?.text else { return }
+        delegate?.homeCarouselCollectionViewDidTouchedTagButton(self, tag: tag)
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeInteractor.swift
@@ -13,12 +13,15 @@ protocol HomeBusinessLogic {
     func fetchThumbnailImageData(with request: HomeModels.FetchThumbnailImageData.Request)
     func playPosts(with request: HomeModels.PlayPosts.Request)
     func selectVideo(with request: HomeModels.SelectVideo.Request)
+    func showTagPlayList(with request: HomeModels.ShowTagPlayList.Request)
 }
 
 protocol HomeDataStore {
     var posts: [Post]? { get set }
     var postPlayStartIndex: Int? { get set }
     var selectedVideoURL: URL? { get set }
+
+    var selectedTag: String? { get set }
 }
 
 final class HomeInteractor: HomeDataStore {
@@ -36,10 +39,7 @@ final class HomeInteractor: HomeDataStore {
     var posts: [Post]?
     var postPlayStartIndex: Int?
     var selectedVideoURL: URL?
-
-    func selectVideo(with request: Models.SelectVideo.Request) {
-        selectedVideoURL = videoFileWorker?.copyToNewURL(at: request.videoURL)
-    }
+    var selectedTag: String?
 }
 
 // MARK: - Use Case
@@ -71,5 +71,14 @@ extension HomeInteractor: HomeBusinessLogic {
     func playPosts(with request: HomeModels.PlayPosts.Request) {
         postPlayStartIndex = request.selectedIndex
         presenter?.presentPlaybackScene(with: Models.PlayPosts.Response())
+    }
+
+    func selectVideo(with request: Models.SelectVideo.Request) {
+        selectedVideoURL = videoFileWorker?.copyToNewURL(at: request.videoURL)
+    }
+
+    func showTagPlayList(with request: HomeModels.ShowTagPlayList.Request) {
+        selectedTag = request.tag
+        presenter?.presentTagPlayList(with: Models.ShowTagPlayList.Response())
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeModels.swift
@@ -75,6 +75,18 @@ enum HomeModels {
         }
     }
 
+    enum ShowTagPlayList {
+        struct Request {
+            let tag: String
+        }
+
+        struct Response {
+        }
+
+        struct ViewModel {
+        }
+    }
+
     enum MoveToPlaybackScene {
         struct Request {
             let index: Int

--- a/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
@@ -12,6 +12,7 @@ protocol HomePresentationLogic {
     func presentPosts(with response: HomeModels.FetchPosts.Response)
     func presentThumbnailImage(with response: HomeModels.FetchThumbnailImageData.Response)
     func presentPlaybackScene(with response: HomeModels.PlayPosts.Response)
+    func presentTagPlayList(with response: HomeModels.ShowTagPlayList.Response)
 }
 
 final class HomePresenter: HomePresentationLogic {
@@ -51,5 +52,11 @@ final class HomePresenter: HomePresentationLogic {
 
     func presentPlaybackScene(with response: HomeModels.PlayPosts.Response) {
         viewController?.routeToPlayback()
+    }
+
+    // MARK: - UseCase - TagPlayList
+
+    func presentTagPlayList(with response: HomeModels.ShowTagPlayList.Response) {
+        viewController?.routeToTagPlayList()
     }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeRouter.swift
@@ -12,6 +12,7 @@ protocol HomeRoutingLogic {
     func routeToNext()
     func routeToEditVideo()
     func routeToPlayback()
+    func routeToTagPlay()
 }
 
 protocol HomeDataPassing {
@@ -42,6 +43,7 @@ final class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
         destination.videos = transData(videos: source.posts ?? [])
         viewController?.navigationController?.pushViewController(playbackViewController, animated: true)
     }
+
     func routeToEditVideo() {
         let nextViewController = EditVideoViewController()
         guard let source = dataStore,
@@ -60,9 +62,19 @@ final class HomeRouter: NSObject, HomeRoutingLogic, HomeDataPassing {
             return PlaybackModels.PlaybackVideo(post: video)
         }
     }
+
+    func routeToTagPlay() {
+        let nextViewController = TagPlayListViewController()
+
+        guard let dataStore,
+              var destination = nextViewController.router?.dataStore else { return }
+        passDataToTagPlayList(source: dataStore, destination: &destination)
+        viewController?.navigationController?.pushViewController(nextViewController, animated: true)
+    }
+
     // MARK: - Data Passing
 
-    // func passDataTo(_ destinationDS: inout NextDataStore, from sourceDS: HomeDataStore) {
-    //     destinationDS.attribute = sourceDS.attribute
-    // }
+    private func passDataToTagPlayList(source: HomeDataStore, destination: inout TagPlayListDataStore) {
+        destination.titleTag = source.selectedTag
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -13,6 +13,7 @@ protocol HomeDisplayLogic: AnyObject {
     func displayPosts(with viewModel: HomeModels.FetchPosts.ViewModel)
     func displayThumbnailImage(with viewModel: HomeModels.FetchThumbnailImageData.ViewModel)
     func routeToPlayback()
+    func routeToTagPlayList()
 }
 
 final class HomeViewController: BaseViewController {
@@ -62,6 +63,7 @@ final class HomeViewController: BaseViewController {
                                                                                               indexPath: indexPath))
         cell.setVideo(url: post.videoURL, loopingAt: .zero)
         cell.configure(title: post.title, tags: post.tags)
+        cell.delegate = self
         return cell
     }
 
@@ -121,6 +123,8 @@ final class HomeViewController: BaseViewController {
         carouselCollectionView.delegate = self
     }
 
+    // MARK: - Methods
+
     private func createCarouselLayout(groupWidthDimension: CGFloat,
                                       groupHeightDimension: CGFloat,
                                       maximumZoomScale: CGFloat,
@@ -177,8 +181,15 @@ final class HomeViewController: BaseViewController {
         centerCell.playVideo()
     }
 
+    // MARK: - Actions
+
     @objc private func uploadButtonDidTap() {
-        self.present(phPickerViewController, animated: true)
+        present(phPickerViewController, animated: true)
+    }
+
+    @objc private func tagButtonDidTap(_ sender: UIButton) {
+        guard let tag = sender.titleLabel?.text else { return }
+        interactor?.showTagPlayList(with: Models.ShowTagPlayList.Request(tag: tag))
     }
 
     // MARK: - Use Case
@@ -188,9 +199,19 @@ final class HomeViewController: BaseViewController {
     }
 }
 
+// MARK: - UICollectionViewDelegate
+
 extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         interactor?.playPosts(with: Models.PlayPosts.Request(selectedIndex: indexPath.item))
+    }
+}
+
+// MARK: - HomeCarouselCollectionViewDelegate
+
+extension HomeViewController: HomeCarouselCollectionViewDelegate {
+    func homeCarouselCollectionViewDidTouchedTagButton(_ cell: HomeCarouselCollectionViewCell, tag: String) {
+        interactor?.showTagPlayList(with: Models.ShowTagPlayList.Request(tag: tag))
     }
 }
 
@@ -250,5 +271,9 @@ extension HomeViewController: HomeDisplayLogic {
 
     func routeToPlayback() {
         router?.routeToPlayback()
+    }
+
+    func routeToTagPlayList() {
+        router?.routeToTagPlay()
     }
 }

--- a/iOS/Layover/Layover/Workers/Mocks/MockTagPlayListWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockTagPlayListWorker.swift
@@ -13,7 +13,7 @@ final class MockTagPlayListWorker: TagPlayListWorkerProtocol {
 
     // MARK: - Properties
 
-    private let provider: ProviderType = Provider(session: .initMockSession())
+    private let provider: ProviderType = Provider(session: .initMockSession(), authManager: StubAuthManager())
     private let headers: [String: String] = ["Content-Type": "application/json",
                                              "Authorization": "mock token"]
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.
캐러셀 태그 버튼 누를 때, 태그 검색 뷰로 전환하도록 구현했습니다.

#### 📌 변경 사항
- cell 내부에 버튼이 있어서, target-action 메서드로 delegate를 호출하고, delegate인 홈 뷰컨에서 route 메서드를 실행시키는 흐름입니다.

##### 📸 ScreenShot
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-04 at 00 40 32](https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/91a65540-bb52-4b25-a2ef-9d6abf38106c)

#### Linked Issue
close #185 
