### PR TITLE
chore: MockWorker 의존성 수정

### DIFF
--- a/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
@@ -20,8 +20,6 @@ final class MockLoginWorker: LoginWorkerProtocol {
         self.provider = provider
     }
 
-    private let headers: [String: String] = ["Content-Type": "application/json", "Authorization": "mock token"]
-
     // MARK: - Methods
 
     func fetchKakaoLoginToken() async -> String? {

--- a/iOS/Layover/Layover/Workers/Mocks/MockTagPlayListWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockTagPlayListWorker.swift
@@ -13,9 +13,8 @@ final class MockTagPlayListWorker: TagPlayListWorkerProtocol {
 
     // MARK: - Properties
 
-    private let provider: ProviderType = Provider(session: .initMockSession())
-    private let headers: [String: String] = ["Content-Type": "application/json",
-                                             "Authorization": "mock token"]
+    private let provider: ProviderType = Provider(session: .initMockSession(), 
+                                                  authManager: StubAuthManager())
 
     // MARK: - Methods
 
@@ -36,8 +35,7 @@ final class MockTagPlayListWorker: TagPlayListWorkerProtocol {
 
             let endPoint = EndPoint<Response<[PostDTO]>>(path: "/board/tag",
                                                          method: .GET,
-                                                         queryParameters: ["tag": tag],
-                                                         headers: headers)
+                                                         queryParameters: ["tag": tag])
 
             let response = try await provider.request(with: endPoint)
             return response.data?.map { $0.toDomain() }

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -13,7 +13,8 @@ final class MockUserWorker: UserWorkerProtocol {
 
     // MARK: - Properties
 
-    private let provider: ProviderType = Provider(session: .initMockSession())
+    private let provider: ProviderType = Provider(session: .initMockSession(), 
+                                                  authManager: StubAuthManager())
 
     // MARK: - Methods
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- MockWorker 들의 Provider의 authmanager를 stub으로 모두 교체했습니다.
- EndPointFactory 의존성도 제거하여 주었습니다.

#### 📌 변경 사항
EndPointFactory 의존성도 제거한 이유는 일관성과 Mock 객체인 이상, 다른 객체의 의존을 최대한 덜어내는 것이 좋다고 생각했기 때문입니다.
혹시 더 좋은 의견있으시면 남겨주세요:)

#### Linked Issue
close #190 
