### PR TITLE
feat: 업로드용 메서드 구현

### DIFF
--- a/iOS/Layover/Layover/Network/Provider/Provider.swift
+++ b/iOS/Layover/Layover/Network/Provider/Provider.swift
@@ -103,7 +103,7 @@ class Provider: ProviderType {
     // 이미지 업로드용
     func upload(data: Data, to url: String, method: HTTPMethod = .PUT) async throws -> Data {
         guard let url = URL(string: url) else { throw NetworkError.components }
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = method.rawValue
 
         let (data, response) = try await session.upload(for: request, from: data)
@@ -118,7 +118,7 @@ class Provider: ProviderType {
                           sessionTaskDelegate: URLSessionTaskDelegate? = nil,
                           delegateQueue: OperationQueue? = nil) async throws -> Data {
         guard let url = URL(string: url) else { throw NetworkError.components }
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = method.rawValue
         let backgroundSession = URLSession(configuration: .background(withIdentifier: UUID().uuidString),
                                            delegate: sessionTaskDelegate,

--- a/iOS/Layover/Layover/Network/Provider/Provider.swift
+++ b/iOS/Layover/Layover/Network/Provider/Provider.swift
@@ -111,13 +111,19 @@ class Provider: ProviderType {
         return data
     }
 
-    func backgroundUpload(fromFile: URL, to url: String, method: HTTPMethod = .PUT) async throws -> Data {
+    // 동영상 업로드용
+    func backgroundUpload(fromFile: URL,
+                          to url: String,
+                          method: HTTPMethod = .PUT,
+                          sessionTaskDelegate: URLSessionTaskDelegate? = nil,
+                          delegateQueue: OperationQueue? = nil) async throws -> Data {
         guard let url = URL(string: url) else { throw NetworkError.components }
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
-        let backgroundSession = URLSession(configuration: .background(withIdentifier: UUID().uuidString))
-
-        let (data, response) = try await session.upload(for: request, fromFile: fromFile)
+        let backgroundSession = URLSession(configuration: .background(withIdentifier: UUID().uuidString),
+                                           delegate: sessionTaskDelegate,
+                                           delegateQueue: delegateQueue)
+        let (data, response) = try await backgroundSession.upload(for: request, fromFile: fromFile)
         try self.checkStatusCode(of: response)
         return data
     }

--- a/iOS/Layover/Layover/Network/Provider/Provider.swift
+++ b/iOS/Layover/Layover/Network/Provider/Provider.swift
@@ -105,7 +105,6 @@ class Provider: ProviderType {
         guard let url = URL(string: url) else { throw NetworkError.components }
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
-        request.httpBody = data
 
         let (data, response) = try await session.upload(for: request, from: data)
         try self.checkStatusCode(of: response)
@@ -117,7 +116,7 @@ class Provider: ProviderType {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
         let backgroundSession = URLSession(configuration: .background(withIdentifier: UUID().uuidString))
-        
+
         let (data, response) = try await session.upload(for: request, fromFile: fromFile)
         try self.checkStatusCode(of: response)
         return data


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 이미지 업로드용 업로드 메서드 구현
- 동영상 업로드용 백그라운드 업로드 메서드 구현

#### 📌 변경 사항
> [!NOTE] 
> 백그라운드 업로드 메서드 사용법

- 앱에서 progressBar를 표현하려면 업로드가 얼마나 진행되었는지 observing해야 하고, 
  이는 URLSessionTaskDelegate의 didSendBodyData 인자가 있는 메서드를 통해 구현할 수 있습니다.
- 그래서 provider에서 해당 백그라운드 업로드 메서드를 호출하는 곳을 delegate로 주입할 수 있도록 인자를 열어두었습니다.
- 또한 해당 이벤트를 어떤 OperationQueue에서 받을 건지 지정해주어야 하는데, 우리는 보통 UI에 표기하기 위해 main에서 받을 테니까
  OperationQueue.main을 넘기면 될 것 같네요

```swift
func backgroundUpload(fromFile: URL,
                          to url: String,
                          method: HTTPMethod = .PUT,
                          sessionTaskDelegate: URLSessionTaskDelegate? = nil,
                          delegateQueue: OperationQueue? = nil) async throws -> Data {
    guard let url = URL(string: url) else { throw NetworkError.components }
    var request = URLRequest(url: url)
    request.httpMethod = method.rawValue
    let backgroundSession = URLSession(configuration: .background(withIdentifier: UUID().uuidString),
                                       delegate: sessionTaskDelegate,
                                       delegateQueue: delegateQueue)
    let (data, response) = try await backgroundSession.upload(for: request, fromFile: fromFile)
    try self.checkStatusCode(of: response)
    return data
}
```

#### Linked Issue
close #187 
