### PR TITLE
bug: 재생화면 스택 뷰 재사용 이슈

### DIFF
--- a/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
+++ b/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
@@ -62,7 +62,7 @@ final class LOTagStackView: UIStackView {
         addArrangedSubview(button)
     }
 
-    func resetTag() {
+    func resetTagStackView() {
         arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
 

--- a/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
+++ b/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
@@ -63,7 +63,7 @@ final class LOTagStackView: UIStackView {
     }
 
     func resetTag() {
-        self.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        arrangedSubviews.forEach { $0.removeFromSuperview() }
     }
 
     private func setUI() {

--- a/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
+++ b/iOS/Layover/Layover/DesignSystem/LOTagStackView.swift
@@ -62,6 +62,10 @@ final class LOTagStackView: UIStackView {
         addArrangedSubview(button)
     }
 
+    func resetTag() {
+        self.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    }
+
     private func setUI() {
         self.alignment = .fill
         self.distribution = .fillProportionally

--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -25,6 +25,7 @@ final class PlaybackCell: UICollectionViewCell {
         playbackView.descriptionView.titleLabel.text = info.title
         playbackView.descriptionView.setText(info.content)
         playbackView.profileLabel.text = info.profileName
+        playbackView.tagStackView.resetTag()
         info.tag.forEach { tag in
             playbackView.tagStackView.addTag(tag)
         }

--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -25,7 +25,7 @@ final class PlaybackCell: UICollectionViewCell {
         playbackView.descriptionView.titleLabel.text = info.title
         playbackView.descriptionView.setText(info.content)
         playbackView.profileLabel.text = info.profileName
-        playbackView.tagStackView.resetTag()
+        playbackView.tagStackView.resetTagStackView()
         info.tag.forEach { tag in
             playbackView.tagStackView.addTag(tag)
         }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -123,9 +123,7 @@ final class PlaybackViewController: BaseViewController {
         let window = windowScene?.windows.first
         guard let playerSliderWidth: CGFloat = windowScene?.screen.bounds.width else { return }
         guard let windowHeight: CGFloat = windowScene?.screen.bounds.height else { return }
-        guard let tabBarHeight: CGFloat = self.tabBarController?.tabBar.frame.height else {
-            return
-        }
+        guard let tabBarHeight: CGFloat = self.tabBarController?.tabBar.frame.height else { return }
         playerSlider.frame = CGRect(x: 0, y: (windowHeight - tabBarHeight - LOSlider.loSliderHeight / 2), width: playerSliderWidth, height: LOSlider.loSliderHeight)
         window?.addSubview(playerSlider)
         playerSlider.window?.windowLevel = UIWindow.Level.normal + 1
@@ -151,7 +149,7 @@ final class PlaybackViewController: BaseViewController {
             try await Task.sleep(nanoseconds: 1_000_000_00)
             playerSlider.isHidden = false
         } catch {
-            os_log("Falie Waiting show Player Slider")
+            os_log("Fail Waiting show Player Slider")
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
@@ -18,7 +18,8 @@ final class PlaybackWorker {
 
     func makeInfiniteScroll(posts: [Post]) -> [Post] {
         var tempVideos: [Post] = posts
-        let tempLastVideo: Post = posts[tempVideos.count-1]
+        let tempFirstCellIndex: Int = posts.count == 1 ? 1 : 0
+        let tempLastVideo: Post = posts[tempFirstCellIndex]
         let tempFirstVideo: Post = posts[1]
         tempVideos.insert(tempLastVideo, at: 0)
         tempVideos.append(tempFirstVideo)


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
재생화면에서의 스택뷰 재사용 이슈가 있어 태그 스택뷰를 처리해 주는 작업을 했습니다.
UI에 관련된 내용이므로 prepareforreuse가 아닌 cell configure하는 부분에서 처리했습니다.
짜잘한 리팩토링(줄바꿈, 오타)수정이 있습니다.

#### 📌 변경 사항
없슴다.

##### 📸 ScreenShot

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/89f5d472-cf13-4112-999a-14bf36996b27



#### Linked Issue
close #199 
