### PR TITLE
feat: pagination 추가 및 버그 수정

### DIFF
--- a/BE/layover/src/board/board.service.ts
+++ b/BE/layover/src/board/board.service.ts
@@ -81,7 +81,7 @@ export class BoardService {
       board.content,
       board.status,
     );
-    const tag = board.tags.map((tag) => tag.tagname);
+    const tag = board.tags ? board.tags.map((tag) => tag.tagname) : [];
     return new BoardsResDto(member, boardInfo, tag);
   }
 

--- a/BE/layover/src/board/board.service.ts
+++ b/BE/layover/src/board/board.service.ts
@@ -101,13 +101,18 @@ export class BoardService {
     return Promise.all(boards.map((board) => this.createBoardResDto(board)));
   }
 
-  async getBoardTag(tag: string) {
+  async getBoardTag(tag: string, page: number) {
+    const itemsPerPage = 15;
+    const offset = (page - 1) * itemsPerPage;
+
     const boards: Board[] = await this.boardRepository
       .createQueryBuilder('board')
       .leftJoinAndSelect('board.member', 'member')
       .leftJoinAndSelect('board.tags', 'tag')
       .where('tag.tagname = :tag', { tag })
       .andWhere("board.status = 'COMPLETE'")
+      .skip(offset)
+      .take(itemsPerPage)
       .getMany();
 
     const boardIds = boards.map((board) => board.id);
@@ -122,13 +127,18 @@ export class BoardService {
     return Promise.all(allBoards.map((board) => this.createBoardResDto(board)));
   }
 
-  async getBoardProfile(id: number) {
+  async getBoardProfile(id: number, page: number) {
+    const itemsPerPage = 15;
+    const offset = (page - 1) * itemsPerPage;
+
     const boards: Board[] = await this.boardRepository
       .createQueryBuilder('board')
       .leftJoinAndSelect('board.member', 'member')
       .leftJoinAndSelect('board.tags', 'tag')
       .where("board.status = 'COMPLETE'")
       .andWhere('member.id = :id', { id })
+      .skip(offset)
+      .take(itemsPerPage)
       .getMany();
     return Promise.all(boards.map((board) => this.createBoardResDto(board)));
   }

--- a/BE/layover/src/board/board.service.ts
+++ b/BE/layover/src/board/board.service.ts
@@ -20,11 +20,11 @@ export class BoardService {
 
   async createBoard(userId: number, title: string, content: string, latitude: number, longitude: number, tag: string[]): Promise<CreateBoardResDto> {
     const member: Member = await this.memberService.findMemberById(userId);
-
+    content = content ?? '';
     const savedBoard: Board = await this.boardRepository.save({
       member: member,
       title: title,
-      content: content ?? '',
+      content: content,
       encoded_video_url: '',
       latitude: latitude,
       longitude: longitude,
@@ -37,7 +37,7 @@ export class BoardService {
       });
     }
 
-    return new CreateBoardResDto(savedBoard.id, title, content, latitude, longitude, tag);
+    return new CreateBoardResDto(savedBoard.id, title, content, latitude, longitude, tag ?? []);
   }
 
   async getBoardRandom() {

--- a/BE/layover/src/board/board.service.ts
+++ b/BE/layover/src/board/board.service.ts
@@ -20,19 +20,22 @@ export class BoardService {
 
   async createBoard(userId: number, title: string, content: string, latitude: number, longitude: number, tag: string[]): Promise<CreateBoardResDto> {
     const member: Member = await this.memberService.findMemberById(userId);
+
     const savedBoard: Board = await this.boardRepository.save({
       member: member,
       title: title,
-      content: content,
+      content: content ?? '',
       encoded_video_url: '',
       latitude: latitude,
       longitude: longitude,
       filename: '',
       status: 'WAITING',
     });
-    tag.map(async (tagname) => {
-      await this.tagService.saveTag(savedBoard, tagname);
-    });
+    if (tag) {
+      tag.map(async (tagname) => {
+        await this.tagService.saveTag(savedBoard, tagname);
+      });
+    }
 
     return new CreateBoardResDto(savedBoard.id, title, content, latitude, longitude, tag);
   }

--- a/BE/layover/src/board/dtos/create-board.dto.ts
+++ b/BE/layover/src/board/dtos/create-board.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateBoardDto {
   @ApiProperty({
@@ -11,10 +11,11 @@ export class CreateBoardDto {
   @ApiProperty({
     example: 'chilling at the beach~',
     description: '내용',
+    required: false,
   })
   @IsString()
-  @IsNotEmpty()
-  readonly content: string;
+  @IsOptional()
+  readonly content?: string;
 
   @ApiProperty({
     example: '37.0532156213',
@@ -31,6 +32,8 @@ export class CreateBoardDto {
   @ApiProperty({
     example: ['부산', '광안리', '바다'],
     description: '사용자가 작성한 태그들',
+    required: false,
   })
-  readonly tag: string[];
+  @IsOptional()
+  readonly tag?: string[];
 }

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -85,5 +85,5 @@ export const SWAGGER = {
     required: true,
   },
 
-  MEMBER_ID_QUERY_STRING: { name: 'memberId', required: false },
+  MEMBER_ID_QUERY_STRING: { name: 'memberId', required: false, description: '회원 아이디 (생략하면 본인 정보 요청)' },
 };


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- tag 게시글 조회 및 프로필 게시글 조회시 페이지네이션 적용 (15개)
  -> 3개의 그리드로 구성되어있기에 3의배수로 처리
  -> 한 화면에 9개 정도 보이나 바로 콜 하는걸 방지하여 15개정도로 설정
- content와 tag를 optional로 처리
  -> content와 tag없이도 게시물 생성 가능

#### Linked Issue
close #203 
