### PR TITLE
bug: jwt bearer 헤더 처리

### DIFF
--- a/BE/layover/src/board/board.controller.ts
+++ b/BE/layover/src/board/board.controller.ts
@@ -5,7 +5,7 @@ import { ECustomCode } from '../response/ecustom-code.jenum';
 import { CustomResponse } from '../response/custom-response';
 import { BoardPreSignedUrlDto } from './dtos/board-pre-signed-url.dto';
 import { CreateBoardDto } from './dtos/create-board.dto';
-import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CreateBoardResDto } from './dtos/create-board-res.dto';
 import { UploadCallbackDto } from './dtos/upload-callback.dto';
 import { EncodingCallbackDto } from './dtos/encoding-callback.dto';
@@ -30,7 +30,7 @@ export class BoardController {
     description: '게시글에 들어갈 내용들과 함께 업로드를 요청합니다.',
   })
   @ApiResponse(BOARD_SWAGGER.CREATE_BOARD_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Post()
   async createBoard(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() createBoardDto: CreateBoardDto) {
     const savedBoard: CreateBoardResDto = await this.boardService.createBoard(
@@ -49,7 +49,7 @@ export class BoardController {
     description: 'object storage에 영상을 업로드 하기 위한 presigned url을 요청합니다.',
   })
   @ApiResponse(BOARD_SWAGGER.GET_PRESIGNED_URL_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Post('presigned-url')
   async getPreSignedUrl(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() preSignedUrlDto: BoardPreSignedUrlDto) {
     const [filename, filetype] = [uuidv4(), preSignedUrlDto.filetype];
@@ -66,7 +66,7 @@ export class BoardController {
     description: '랜덤 게시물 (최대) 10개를 조회합니다.',
   })
   @ApiResponse(BOARD_SWAGGER.GET_BOARD_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Get('home')
   async getBoardRandom() {
     const boardsRestDto: BoardsResDto[] = await this.boardService.getBoardRandom();
@@ -78,7 +78,7 @@ export class BoardController {
     description: '거리에 따라 지도 화면에 보여질 게시물들을 조회합니다.',
   })
   @ApiResponse(BOARD_SWAGGER.GET_BOARD_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Get('map')
   async getBoardMap(
     @CustomHeader(new JwtValidationPipe()) payload: tokenPayload,
@@ -90,7 +90,7 @@ export class BoardController {
   }
 
   @ApiResponse(BOARD_SWAGGER.GET_BOARD_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Get('tag')
   @ApiOperation({
     summary: '태그별 게시글 조회',
@@ -102,7 +102,7 @@ export class BoardController {
   }
 
   @ApiResponse(BOARD_SWAGGER.GET_BOARD_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @ApiQuery(SWAGGER.MEMBER_ID_QUERY_STRING)
   @Get('profile')
   @ApiOperation({
@@ -128,7 +128,7 @@ export class BoardController {
     throw new CustomResponse(ECustomCode.SUCCESS, boardsRestDto);
   }
 
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Delete()
   @ApiOperation({
     summary: '게시물 삭제',

--- a/BE/layover/src/main.ts
+++ b/BE/layover/src/main.ts
@@ -37,6 +37,16 @@ async function bootstrap() {
     .setDescription('The Layover API description')
     .setVersion('0.0.0.0.1')
     .addTag('Layover')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'JWT',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'token',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config, {
     extraModels: [

--- a/BE/layover/src/member/member.controller.ts
+++ b/BE/layover/src/member/member.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Patch, Post, Query } from '@nestjs/common';
 import { CheckUsernameDto } from './dtos/check-username.dto';
 import { MemberService } from './member.service';
-import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CheckUsernameResDto } from './dtos/check-username-res.dto';
 import { CustomResponse } from 'src/response/custom-response';
 import { ECustomCode } from 'src/response/ecustom-code.jenum';
@@ -45,7 +45,7 @@ export class MemberController {
   })
   @ApiResponse(MEMBER_SWAGGER.UPDATE_USER_NAME_SUCCESS)
   @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Patch('username')
   async updateUsername(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() usernameDto: UsernameDto) {
     const id = payload.memberId;
@@ -68,7 +68,7 @@ export class MemberController {
   })
   @ApiResponse(MEMBER_SWAGGER.UPDATE_INTRODUCE_SUCCESS)
   @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Patch('introduce')
   async updateIntroduce(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() introduceDto: IntroduceDto) {
     const id = payload.memberId;
@@ -87,7 +87,7 @@ export class MemberController {
   })
   @ApiResponse(MEMBER_SWAGGER.GET_MEMBER_INFOS_SUCCESS)
   @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @ApiQuery(SWAGGER.MEMBER_ID_QUERY_STRING)
   @Get()
   async getOtherMemberInfos(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Query('memberId') memberId: string) {
@@ -120,7 +120,7 @@ export class MemberController {
   })
   @ApiResponse(MEMBER_SWAGGER.DELETE_MEMBER_SUCCESS)
   @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Delete()
   async deleteMember(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload) {
     const id = payload.memberId;
@@ -141,7 +141,7 @@ export class MemberController {
   })
   @ApiResponse(MEMBER_SWAGGER.GET_UPLOAD_PROFILE_PRESIGNED_URL_SUCCESS)
   @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Post('profile-image/presigned-url')
   async getUploadProfilePresignedUrl(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() body: ProfilePreSignedUrlDto) {
     const id = payload.memberId;

--- a/BE/layover/src/oauth/oauth.controller.ts
+++ b/BE/layover/src/oauth/oauth.controller.ts
@@ -4,7 +4,7 @@ import { OauthService } from './oauth.service';
 import { JwtValidationPipe } from 'src/pipes/jwt.validation.pipe';
 import { CustomResponse } from '../response/custom-response';
 import { ECustomCode } from '../response/ecustom-code.jenum';
-import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { KakaoLoginDto } from './dtos/kakao-login.dto';
 import { AppleLoginDto } from './dtos/apple-login.dto';
 import { KakaoSignupDto } from './dtos/kakao-signup.dto';
@@ -177,7 +177,7 @@ export class OauthController {
   })
   @ApiResponse(OAUTH_SWAGGER.RENEW_TOKENS_SUCCESS)
   @ApiResponse(SWAGGER.REFRESH_TOKEN_TIMEOUT_RESPONSE)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Post('refresh-token')
   async renewTokens(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload) {
     // 새로운 토큰을 생성하고 이를 반환함

--- a/BE/layover/src/report/report.controller.ts
+++ b/BE/layover/src/report/report.controller.ts
@@ -5,7 +5,7 @@ import { ReportService } from './report.service';
 import { tokenPayload } from 'src/utils/interfaces/token.payload';
 import { CustomResponse } from 'src/response/custom-response';
 import { ECustomCode } from 'src/response/ecustom-code.jenum';
-import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SWAGGER } from 'src/utils/swaggerUtils';
 import { ReportResDto } from './dtos/report-res.dto';
 import { ReportDto } from './dtos/report.dto';
@@ -25,7 +25,7 @@ export class ReportController {
     description: '특정 게시글을 신고합니다.',
   })
   @ApiResponse(REPORT_SWAGGER.RECEIVE_REPORT_SUCCESS)
-  @ApiHeader(SWAGGER.AUTHORIZATION_HEADER)
+  @ApiBearerAuth('token')
   @Post()
   async receiveReport(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload, @Body() body: ReportDto) {
     const responseData: ReportResDto = await this.reportService.insertReport(payload.memberId, body.boardId, body.reportType);


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 스웨거에서 jwt를 보내기 위하여 보안헤더 처리
- @ApiHeader 에서 @ApiBearerAuth로 처리 

##### 📸 ScreenShot
![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/04a1d12a-240e-482f-9c5e-92a0f26f5238)

![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/e5cf27b6-b76d-479f-9ba0-364bc94b6bcd)


api옆에 자물쇠가 생겼으며 클릭하여 값을 넣어줄 수 있음.

