### PR TITLE
feat: 회원가입 시 기존 회원가입 여부 확인 네트워크 연결

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1901D4A22B18F4BE00617A64 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D4A12B18F4BE00617A64 /* System.swift */; };
+		1915D6E52B1FB82000CE1DD0 /* CheckSignUpDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1915D6E42B1FB82000CE1DD0 /* CheckSignUpDTO.swift */; };
+		1915D6E92B1FBABA00CE1DD0 /* CheckSignUp.json in Resources */ = {isa = PBXBuildFile; fileRef = 1915D6E82B1FBABA00CE1DD0 /* CheckSignUp.json */; };
 		193686722B15BCA7008902CD /* UserEndPointFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193686712B15BCA7008902CD /* UserEndPointFactory.swift */; };
 		193686742B15C489008902CD /* UserWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193686732B15C489008902CD /* UserWorker.swift */; };
 		194551F22B037F2D00299768 /* LoginPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194551EC2B037F2D00299768 /* LoginPresenter.swift */; };
@@ -195,6 +197,8 @@
 
 /* Begin PBXFileReference section */
 		1901D4A12B18F4BE00617A64 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
+		1915D6E42B1FB82000CE1DD0 /* CheckSignUpDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSignUpDTO.swift; sourceTree = "<group>"; };
+		1915D6E82B1FBABA00CE1DD0 /* CheckSignUp.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CheckSignUp.json; sourceTree = "<group>"; };
 		193686712B15BCA7008902CD /* UserEndPointFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEndPointFactory.swift; sourceTree = "<group>"; };
 		193686732B15C489008902CD /* UserWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWorker.swift; sourceTree = "<group>"; };
 		194551EC2B037F2D00299768 /* LoginPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPresenter.swift; sourceTree = "<group>"; };
@@ -565,6 +569,7 @@
 				19A1693B2B17BD1C00DB34C0 /* BoardDTO.swift */,
 				836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */,
 				836C338E2B160CC700ECAFB0 /* MemberDTO.swift */,
+				1915D6E42B1FB82000CE1DD0 /* CheckSignUpDTO.swift */,
 			);
 			path = DTOs;
 			sourceTree = "<group>";
@@ -765,6 +770,7 @@
 				FC767F9A2B12283D0088CF9B /* PatchUserName.json */,
 				835783C52B14A5C800E7D304 /* LoginData.json */,
 				19A169352B178EA500DB34C0 /* PostList.json */,
+				1915D6E82B1FBABA00CE1DD0 /* CheckSignUp.json */,
 			);
 			path = MockData;
 			sourceTree = "<group>";
@@ -939,8 +945,8 @@
 				1972CCD32B138E6B00C3C762 /* SignUpRouter.swift */,
 				FCEE0FF92B03AF8400195BBE /* SignUpViewController.swift */,
 				FC25119F2B045C0A004717BC /* SignUpInteractor.swift */,
-				1972CCD92B13A4BA00C3C762 /* SignUpWorker.swift */,
 				FC2511A12B045C3F004717BC /* SignUpPresenter.swift */,
+				1972CCD92B13A4BA00C3C762 /* SignUpWorker.swift */,
 				FC2511A52B049020004717BC /* SignUpConfigurator.swift */,
 			);
 			path = SignUpScene;
@@ -1048,6 +1054,7 @@
 				FC767FA12B12283D0088CF9B /* DeleteUser.json in Resources */,
 				FC7E45462AFEB62B004F155A /* LaunchScreen.storyboard in Resources */,
 				19A169362B178EA500DB34C0 /* PostList.json in Resources */,
+				1915D6E92B1FBABA00CE1DD0 /* CheckSignUp.json in Resources */,
 				FC767FA02B12283D0088CF9B /* CheckUserName.json in Resources */,
 				FC4975932B03432800D8627F /* Pretendard-Bold.ttf in Resources */,
 				FC7E45432AFEB62B004F155A /* Assets.xcassets in Resources */,
@@ -1197,6 +1204,7 @@
 				1945522A2B04883800299768 /* UIView+.swift in Sources */,
 				FCE52FFA2B0FCB0A002CDB75 /* URLSession+.swift in Sources */,
 				19743C052B06940D001E405A /* PlayerView.swift in Sources */,
+				1915D6E52B1FB82000CE1DD0 /* CheckSignUpDTO.swift in Sources */,
 				83C35E1B2B108C3500D8DD5C /* PlaybackView.swift in Sources */,
 				835A61A02B068115002F22A5 /* PlaybackModels.swift in Sources */,
 				FC0E80292B1A0BBB00EF56D6 /* UploadPostInteractor.swift in Sources */,

--- a/iOS/Layover/Layover/Network/DTOs/CheckSignUpDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/CheckSignUpDTO.swift
@@ -1,0 +1,13 @@
+//
+//  CheckSignUpDTO.swift
+//  Layover
+//
+//  Created by 김인환 on 12/6/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+struct CheckSignUpDTO: Decodable {
+    let isValid: Bool
+}

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
@@ -12,6 +12,8 @@ protocol LoginEndPointFactory {
     func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>>
     func makeTokenRefreshEndPoint(with refreshToken: String) -> EndPoint<Response<LoginDTO>>
     func makeAppleLoginEndPoint(with identityToken: String) -> EndPoint<Response<LoginDTO>>
+    func makeCheckKakaoIsSignedUp(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>>
+    func makeCheckAppleIsSignedUp(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>>
 }
 
 struct DefaultLoginEndPointFactory: LoginEndPointFactory {
@@ -45,6 +47,27 @@ struct DefaultLoginEndPointFactory: LoginEndPointFactory {
             path: "/oauth/apple",
             method: .POST,
             bodyParameters: bodyParameters)
+    }
 
+    func makeCheckKakaoIsSignedUp(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(socialToken, forKey: "accessToken")
+
+        return EndPoint(
+            path: "/oauth/check-signup/kakao",
+            method: .POST,
+            bodyParameters: bodyParameters
+        )
+    }
+
+    func makeCheckAppleIsSignedUp(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(identityToken, forKey: "identityToken")
+
+        return EndPoint(
+            path: "/oauth/check-signup/apple",
+            method: .POST,
+            bodyParameters: bodyParameters
+        )
     }
 }

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/LoginEndPointFactory.swift
@@ -12,8 +12,8 @@ protocol LoginEndPointFactory {
     func makeKakaoLoginEndPoint(with socialToken: String) -> EndPoint<Response<LoginDTO>>
     func makeTokenRefreshEndPoint(with refreshToken: String) -> EndPoint<Response<LoginDTO>>
     func makeAppleLoginEndPoint(with identityToken: String) -> EndPoint<Response<LoginDTO>>
-    func makeCheckKakaoIsSignedUp(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>>
-    func makeCheckAppleIsSignedUp(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>>
+    func makeCheckKakaoIsSignedUpEndPoint(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>>
+    func makeCheckAppleIsSignedUpEndPoint(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>>
 }
 
 struct DefaultLoginEndPointFactory: LoginEndPointFactory {
@@ -49,7 +49,7 @@ struct DefaultLoginEndPointFactory: LoginEndPointFactory {
             bodyParameters: bodyParameters)
     }
 
-    func makeCheckKakaoIsSignedUp(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
+    func makeCheckKakaoIsSignedUpEndPoint(with socialToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
         var bodyParameters = [String: String]()
         bodyParameters.updateValue(socialToken, forKey: "accessToken")
 
@@ -60,7 +60,7 @@ struct DefaultLoginEndPointFactory: LoginEndPointFactory {
         )
     }
 
-    func makeCheckAppleIsSignedUp(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
+    func makeCheckAppleIsSignedUpEndPoint(with identityToken: String) -> EndPoint<Response<CheckSignUpDTO>> {
         var bodyParameters = [String: String]()
         bodyParameters.updateValue(identityToken, forKey: "identityToken")
 

--- a/iOS/Layover/Layover/Network/Mock/MockData/CheckSignUp.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/CheckSignUp.json
@@ -1,0 +1,8 @@
+{
+    "customCode": "SUCCESS",
+    "message": "성공",
+    "statusCode": 200,
+    "data": {
+        "isValid": true
+    }
+}

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -80,7 +80,7 @@ extension LoginInteractor: ASAuthorizationControllerDelegate {
                 async let isRegistered: Bool = worker?.isRegisteredApple(with: identityToken) ?? false
                 async let loginResult: Bool = worker?.loginApple(with: identityToken) ?? false
 
-                if await isRegistered, await loginResult {
+                if await !isRegistered, await loginResult {
                     await MainActor.run {
                         presenter?.presentPerformLogin()
                     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -42,7 +42,8 @@ extension LoginInteractor: LoginBusinessLogic {
         Task {
             guard let token = await worker?.fetchKakaoLoginToken() else { return }
             kakaoLoginToken = token
-            if await worker?.isRegisteredKakao(with: token) == true, await worker?.loginKakao(with: token) == true {
+            if await worker?.isRegisteredKakao(with: token) == true,
+                await worker?.loginKakao(with: token) == true {
                 await MainActor.run {
                     presenter?.presentPerformLogin()
                 }
@@ -61,7 +62,6 @@ extension LoginInteractor: LoginBusinessLogic {
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = request.loginViewController
         authorizationController.performRequests()
-
     }
 }
 

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -14,9 +14,9 @@ import OSLog
 
 protocol LoginWorkerProtocol {
     @MainActor func fetchKakaoLoginToken() async -> String?
-    func isRegisteredKakao(with socialToken: String) async -> Bool
+    func isRegisteredKakao(with socialToken: String) async -> Bool?
     func loginKakao(with socialToken: String) async -> Bool
-    func isRegisteredApple(with identityToken: String) async -> Bool
+    func isRegisteredApple(with identityToken: String) async -> Bool?
     func loginApple(with identityToken: String) async -> Bool
 }
 
@@ -30,7 +30,9 @@ final class LoginWorker: NSObject {
     let loginEndPointFactory: LoginEndPointFactory
     let authManager: AuthManager
 
-    init(provider: ProviderType = Provider(), loginEndPointFactory: LoginEndPointFactory = DefaultLoginEndPointFactory(), authManager: AuthManager = .shared) {
+    init(provider: ProviderType = Provider(), 
+         loginEndPointFactory: LoginEndPointFactory = DefaultLoginEndPointFactory(),
+         authManager: AuthManager = .shared) {
         self.provider = provider
         self.authManager = authManager
         self.loginEndPointFactory = loginEndPointFactory
@@ -67,23 +69,21 @@ extension LoginWorker: LoginWorkerProtocol {
         }
     }
 
-    func isRegisteredKakao(with socialToken: String) async -> Bool {
-        // TODO: 회원가입 여부 판단. 추후 서버 바뀌면 구현
-        return false
-//        do {
-//            let endPoint = loginEndPointFactory.makeKakaoLoginEndPoint(with: socialToken)
-//            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
-//            return true
-//        } catch {
-//            os_log(.error, log: .data, "%@", error.localizedDescription)
-//            return false
-//        }
+    func isRegisteredKakao(with socialToken: String) async -> Bool? {
+        do {
+            let endPoint = loginEndPointFactory.makeCheckKakaoIsSignedUp(with: socialToken)
+            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
+            return result.data?.isValid
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
     }
 
     func loginKakao(with socialToken: String) async -> Bool {
         do {
             let endPoint = loginEndPointFactory.makeKakaoLoginEndPoint(with: socialToken)
-            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
 
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken
@@ -97,15 +97,21 @@ extension LoginWorker: LoginWorkerProtocol {
 
     // MARK: - Apple Login
 
-    func isRegisteredApple(with identityToken: String) async -> Bool {
-        // TODO: 회원가입 여부 판단
-        return false
+    func isRegisteredApple(with identityToken: String) async -> Bool? {
+        do {
+            let endPoint = loginEndPointFactory.makeCheckAppleIsSignedUp(with: identityToken)
+            let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
+            return result.data?.isValid
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
     }
 
     func loginApple(with identityToken: String) async -> Bool {
         do {
             let endPoint: EndPoint = loginEndPointFactory.makeAppleLoginEndPoint(with: identityToken)
-            let result: EndPoint<Response<LoginDTO>>.Response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            let result: EndPoint<Response<LoginDTO>>.Response = try await provider.request(with: endPoint, authenticationIfNeeded: false)
 
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -71,7 +71,7 @@ extension LoginWorker: LoginWorkerProtocol {
 
     func isRegisteredKakao(with socialToken: String) async -> Bool? {
         do {
-            let endPoint = loginEndPointFactory.makeCheckKakaoIsSignedUp(with: socialToken)
+            let endPoint = loginEndPointFactory.makeCheckKakaoIsSignedUpEndPoint(with: socialToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
             return result.data?.isValid
         } catch {
@@ -99,7 +99,7 @@ extension LoginWorker: LoginWorkerProtocol {
 
     func isRegisteredApple(with identityToken: String) async -> Bool? {
         do {
-            let endPoint = loginEndPointFactory.makeCheckAppleIsSignedUp(with: identityToken)
+            let endPoint = loginEndPointFactory.makeCheckAppleIsSignedUpEndPoint(with: identityToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
             return result.data?.isValid
         } catch {

--- a/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
@@ -26,8 +26,34 @@ final class MockLoginWorker: LoginWorkerProtocol {
         return "mock token"
     }
 
-    func isRegisteredKakao(with socialToken: String) async -> Bool {
-        return false
+    func isRegisteredKakao(with socialToken: String) async -> Bool? {
+        guard let fileLocation = Bundle.main.url(forResource: "CheckSignUp", withExtension: "json") else {
+            os_log(.error, log: .data, "CheckSignUp.json 파일이 존재하지 않습니다.")
+            return nil
+        }
+        guard let mockData = try? Data(contentsOf: fileLocation) else {
+            os_log(.error, log: .data, "CheckSignUp.json 파일을 읽어올 수 없습니다.")
+            return nil
+        }
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)
+            return (response, mockData, nil)
+        }
+        do {
+            var bodyParameters = [String: String]()
+            bodyParameters.updateValue(socialToken, forKey: "accessToken")
+            let endPoint = EndPoint<Response<CheckSignUpDTO>>(path: "/oauth/check-signup/kakao",
+                                                              method: .POST,
+                                                              bodyParameters: bodyParameters)
+            let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            return response.data?.isValid
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
     }
 
     func loginKakao(with socialToken: String) async -> Bool {
@@ -58,9 +84,34 @@ final class MockLoginWorker: LoginWorkerProtocol {
         }
     }
 
-    func isRegisteredApple(with identityToken: String) async -> Bool {
-        // TODO: 로직 구현
-        return false
+    func isRegisteredApple(with identityToken: String) async -> Bool? {
+        guard let fileLocation = Bundle.main.url(forResource: "CheckSignUp", withExtension: "json") else {
+            os_log(.error, log: .data, "CheckSignUp.json 파일이 존재하지 않습니다.")
+            return nil
+        }
+        guard let mockData = try? Data(contentsOf: fileLocation) else {
+            os_log(.error, log: .data, "CheckSignUp.json 파일을 읽어올 수 없습니다.")
+            return nil
+        }
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)
+            return (response, mockData, nil)
+        }
+        do {
+            var bodyParameters = [String: String]()
+            bodyParameters.updateValue(identityToken, forKey: "identityToken")
+            let endPoint = EndPoint<Response<CheckSignUpDTO>>(path: "/oauth/check-signup/apple",
+                                                              method: .POST,
+                                                              bodyParameters: bodyParameters)
+            let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
+            return response.data?.isValid
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
     }
 
     func loginApple(with identityToken: String) async -> Bool {


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
회원 가입 시 기존 가입 여부를 확인하는 API 엔드포인트를 연결했습니다.

#### 📌 변경 사항
지금은 True를 MockData로 놓아서 기존 회원가입 화면을 스킵하고 지나갑니다!

#### Linked Issue
close #217 
