### PR TITLE
chore: 변경된 서버 API 필드명으로 회원가입 여부 DTO 변경, 코드 리뷰 반영

### DIFF
--- a/iOS/Layover/Layover/Network/DTOs/CheckSignUpDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/CheckSignUpDTO.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 struct CheckSignUpDTO: Decodable {
-    let isValid: Bool
+    let isAlreadyExist: Bool
 }

--- a/iOS/Layover/Layover/Network/Mock/MockData/CheckSignUp.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/CheckSignUp.json
@@ -3,6 +3,6 @@
     "message": "성공",
     "statusCode": 200,
     "data": {
-        "isValid": true
+        "isAlreadyExist": true
     }
 }

--- a/iOS/Layover/Layover/Network/Mock/MockData/LoginData.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/LoginData.json
@@ -1,9 +1,9 @@
 {
-  "customCode": "SUCCESS",
-  "message": "성공",
-  "statusCode": 200,
-  "data": {
-    "accessToken": "mockAccessToken",
-    "refreshToken": "mockRefreshToken"
-  }
+    "customCode": "SUCCESS",
+    "message": "성공",
+    "statusCode": 200,
+    "data": {
+        "accessToken": "mockAccessToken",
+        "refreshToken": "mockRefreshToken"
+    }
 }

--- a/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginInteractor.swift
@@ -43,7 +43,7 @@ extension LoginInteractor: LoginBusinessLogic {
             guard let token = await worker?.fetchKakaoLoginToken() else { return }
             kakaoLoginToken = token
             if await worker?.isRegisteredKakao(with: token) == true,
-                await worker?.loginKakao(with: token) == true {
+               await worker?.loginKakao(with: token) == true {
                 await MainActor.run {
                     presenter?.presentPerformLogin()
                 }
@@ -77,10 +77,10 @@ extension LoginInteractor: ASAuthorizationControllerDelegate {
             }
             appleLoginToken = identityToken
             Task {
-                async let isRegistered: Bool = worker?.isRegisteredApple(with: identityToken) ?? false
-                async let loginResult: Bool = worker?.loginApple(with: identityToken) ?? false
+                let isRegistered = await worker?.isRegisteredApple(with: identityToken)
+                let loginResult = await worker?.loginApple(with: identityToken)
 
-                if await !isRegistered, await loginResult {
+                if isRegistered == true, loginResult == true {
                     await MainActor.run {
                         presenter?.presentPerformLogin()
                     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -73,7 +73,7 @@ extension LoginWorker: LoginWorkerProtocol {
         do {
             let endPoint = loginEndPointFactory.makeCheckKakaoIsSignedUpEndPoint(with: socialToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
-            return result.data?.isValid
+            return result.data?.isAlreadyExist
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil
@@ -101,7 +101,7 @@ extension LoginWorker: LoginWorkerProtocol {
         do {
             let endPoint = loginEndPointFactory.makeCheckAppleIsSignedUpEndPoint(with: identityToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
-            return result.data?.isValid
+            return result.data?.isAlreadyExist
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil

--- a/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockLoginWorker.swift
@@ -49,7 +49,7 @@ final class MockLoginWorker: LoginWorkerProtocol {
                                                               method: .POST,
                                                               bodyParameters: bodyParameters)
             let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
-            return response.data?.isValid
+            return response.data?.isAlreadyExist
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil
@@ -107,7 +107,7 @@ final class MockLoginWorker: LoginWorkerProtocol {
                                                               method: .POST,
                                                               bodyParameters: bodyParameters)
             let response = try await provider.request(with: endPoint, authenticationIfNeeded: false, retryCount: 0)
-            return response.data?.isValid
+            return response.data?.isAlreadyExist
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 변경된 서버 API 필드명 `isAlreadyExist`로 회원가입 여부 DTO 필드명을 변경했습니다.

#### 📌 변경 사항
- MockURLProtocol.requestHandler data race 문제
  - async let을 이용한 병렬 실행으로 카카오 로그인 로직을 애플과 동시에 맞춰주려고 했는데, Mock 메서드 내에서 실행되는 MockURLProtocol.requestHandler 설정부분에서 data race되어 decoding error가 발생하는 이슈가 있었습니다.
  - 당장은 고치려면 Mock쪽을 건드려야 하게 되어서 우선은 각각을 await하는 것으로 변경했습니다.

#### Linked Issue
close #222 
