### PR TITLE
chore: upload notification 개선

### DIFF
--- a/iOS/Layover/Layover/SceneDelegate.swift
+++ b/iOS/Layover/Layover/SceneDelegate.swift
@@ -71,18 +71,15 @@ extension SceneDelegate {
                                                selector: #selector(routeToLoginViewController),
                                                name: .refreshTokenDidExpired,
                                                object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(showProgressView),
-                                               name: .uploadTaskStart,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(progressChanged),
-                                               name: .progressChanged,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(removeProgressView),
-                                               name: .uploadTaskDidComplete,
-                                               object: nil)
+        NotificationCenter.default.addObserver(forName: .uploadTaskStart, object: nil, queue: .main) { [weak self] _ in
+           self?.showProgressView()
+        }
+        NotificationCenter.default.addObserver(forName: .progressChanged, object: nil, queue: .main) { [weak self] notification in
+            self?.progressChanged(notification)
+        }
+        NotificationCenter.default.addObserver(forName: .uploadTaskDidComplete, object: nil, queue: .main) { [weak self] _ in
+            self?.removeProgressView()
+        }
     }
 
     private func removeNotificationObservers() {
@@ -107,7 +104,7 @@ extension SceneDelegate {
         rootNavigationViewController.setViewControllers([LoginViewController()], animated: true)
     }
 
-    @objc private func showProgressView() {
+    private func showProgressView() {
         guard let progressViewWidth = window?.screen.bounds.width,
               let windowHeight = window?.screen.bounds.height,
               let tabBarViewController = window?.rootViewController as? UITabBarController else { return }
@@ -122,7 +119,7 @@ extension SceneDelegate {
     }
 
 
-    @objc private func progressChanged(_ notification: Notification) {
+    private func progressChanged(_ notification: Notification) {
         guard let progress = notification.userInfo?["progress"] as? Float else { return }
         progressView.setProgress(progress, animated: true)
         if progress == 1 {
@@ -130,7 +127,7 @@ extension SceneDelegate {
         }
     }
 
-    @objc private func removeProgressView() {
+    private func removeProgressView() {
         progressView.removeFromSuperview()
     }
 

--- a/iOS/Layover/Layover/Scenes/UploadPost/UploadPostWorker.swift
+++ b/iOS/Layover/Layover/Scenes/UploadPost/UploadPostWorker.swift
@@ -58,15 +58,11 @@ final class UploadPostWorker: NSObject, UploadPostWorkerProtocol {
             _ = try await provider.upload(fromFile: videoURL,
                                                     to: preSignedURLString,
                                                     sessionTaskDelegate: self)
-            await MainActor.run {
-                NotificationCenter.default.post(name: .uploadTaskDidComplete, object: nil)
-            }
+            NotificationCenter.default.post(name: .uploadTaskDidComplete, object: nil)
             return true
         } catch {
             os_log(.error, log: .data, "Failed to upload Video: %@", error.localizedDescription)
-            await MainActor.run {
-                NotificationCenter.default.post(name: .uploadTaskDidComplete, object: nil)
-            }
+            NotificationCenter.default.post(name: .uploadTaskDidComplete, object: nil)
             return false
         }
     }
@@ -76,9 +72,7 @@ final class UploadPostWorker: NSObject, UploadPostWorkerProtocol {
 extension UploadPostWorker: URLSessionTaskDelegate {
 
     func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .uploadTaskStart, object: nil)
-        }
+        NotificationCenter.default.post(name: .uploadTaskStart, object: nil)
     }
 
     func urlSession(
@@ -89,11 +83,7 @@ extension UploadPostWorker: URLSessionTaskDelegate {
         totalBytesExpectedToSend: Int64
     ) {
         let uploadProgress: Float = Float(Double(totalBytesSent) / Double(totalBytesExpectedToSend))
-        DispatchQueue.main.async {
-            NotificationQueue.default.enqueue(Notification(name: .progressChanged,
-                                                           userInfo: ["progress": uploadProgress]),
-                                              postingStyle: .asap)
-        }
+        NotificationCenter.default.post(name: .progressChanged, object: nil, userInfo: ["progress": uploadProgress])
     }
 
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.

- 처음에는 `NotificationQueue`를 사용하려고 했는데 프로그레스바에 경우 바로바로 화면에 반영이 되어야해서 `postingStyle`을 `now`로 지정해주어야 했어요
- 그런데 `now`로 지정해주면 동기적으로 동작하는 NotificationCenter에 post하는 것과 동일해서 그냥 `NotificationCenter`에 Post하도록 변경했습니다 
- 다만 @ objc로 작성된 selector들을 제거했고
- 씬델리게이트에서 수행할 함수들이 모두 화면 업데이트와 관련된 것들이어서 notification이 mainthread에서 돌아갈 수 있도록 queue를 main으로 변경해서 불필요한 코드를 제거했습니다 !

```swift
NotificationCenter.default.addObserver(forName: .uploadTaskStart, object: nil, queue: .main)
```

#### Linked Issue
close #230 
