### PR TITLE
feat: 지도 탭 api 연결

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		FC68E2A32B0233BC001AABFF /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC68E2A22B0233BC001AABFF /* NetworkError.swift */; };
 		FC68E2A52B0233D3001AABFF /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC68E2A42B0233D3001AABFF /* Provider.swift */; };
 		FC70BB2B2B20718A00B37CBE /* VideoPickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC70BB2A2B20718A00B37CBE /* VideoPickerManager.swift */; };
+		FC70BB2F2B20B66300B37CBE /* MapWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC70BB2E2B20B66300B37CBE /* MapWorker.swift */; };
+		FC70BB332B20C96200B37CBE /* LOAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC70BB322B20C96200B37CBE /* LOAnnotation.swift */; };
 		FC767F842B1214A80088CF9B /* MockUserWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767F832B1214A70088CF9B /* MockUserWorker.swift */; };
 		FC767F862B1214C10088CF9B /* CheckUserNameDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767F852B1214C10088CF9B /* CheckUserNameDTO.swift */; };
 		FC767F932B1220CC0088CF9B /* NicknameDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767F922B1220CC0088CF9B /* NicknameDTO.swift */; };
@@ -184,7 +186,6 @@
 		FC767FA32B12283D0088CF9B /* PatchProfileImage.json in Resources */ = {isa = PBXBuildFile; fileRef = FC767F9E2B12283D0088CF9B /* PatchProfileImage.json */; };
 		FC767FA52B125F430088CF9B /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767FA42B125F430088CF9B /* UIViewController+.swift */; };
 		FC767FA82B1269DB0088CF9B /* LOAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767FA72B1269DB0088CF9B /* LOAnnotationView.swift */; };
-		FC767FAA2B126D080088CF9B /* LOAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC767FA92B126D080088CF9B /* LOAnnotation.swift */; };
 		FC7E453A2AFEB623004F155A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7E45392AFEB623004F155A /* AppDelegate.swift */; };
 		FC7E453C2AFEB623004F155A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7E453B2AFEB623004F155A /* SceneDelegate.swift */; };
 		FC7E45432AFEB62B004F155A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC7E45422AFEB62B004F155A /* Assets.xcassets */; };
@@ -383,6 +384,8 @@
 		FC68E2A22B0233BC001AABFF /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		FC68E2A42B0233D3001AABFF /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		FC70BB2A2B20718A00B37CBE /* VideoPickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPickerManager.swift; sourceTree = "<group>"; };
+		FC70BB2E2B20B66300B37CBE /* MapWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWorker.swift; sourceTree = "<group>"; };
+		FC70BB322B20C96200B37CBE /* LOAnnotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LOAnnotation.swift; sourceTree = "<group>"; };
 		FC767F832B1214A70088CF9B /* MockUserWorker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserWorker.swift; sourceTree = "<group>"; };
 		FC767F852B1214C10088CF9B /* CheckUserNameDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckUserNameDTO.swift; sourceTree = "<group>"; };
 		FC767F922B1220CC0088CF9B /* NicknameDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameDTO.swift; sourceTree = "<group>"; };
@@ -395,7 +398,6 @@
 		FC767F9E2B12283D0088CF9B /* PatchProfileImage.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PatchProfileImage.json; sourceTree = "<group>"; };
 		FC767FA42B125F430088CF9B /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		FC767FA72B1269DB0088CF9B /* LOAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOAnnotationView.swift; sourceTree = "<group>"; };
-		FC767FA92B126D080088CF9B /* LOAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LOAnnotation.swift; sourceTree = "<group>"; };
 		FC7E45362AFEB623004F155A /* Layover.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Layover.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC7E45392AFEB623004F155A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FC7E453B2AFEB623004F155A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -611,8 +613,6 @@
 				19A169372B17BCA800DB34C0 /* PostDTO.swift */,
 				19A169392B17BCC400DB34C0 /* MemberDTO.swift */,
 				19A1693B2B17BD1C00DB34C0 /* BoardDTO.swift */,
-				836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */,
-				836C338E2B160CC700ECAFB0 /* MemberDTO.swift */,
 				8321A2FE2B1E428C000A12AF /* ReportDTO.swift */,
 				FC4084C52B1F1C5B00CE4727 /* UploadPostDTO.swift */,
 				FC4084C92B1F291200CE4727 /* UploadVideoDTO.swift */,
@@ -750,13 +750,14 @@
 			isa = PBXGroup;
 			children = (
 				FC767FA62B1269980088CF9B /* Views */,
-				FC767FA92B126D080088CF9B /* LOAnnotation.swift */,
+				FC70BB322B20C96200B37CBE /* LOAnnotation.swift */,
 				FC2511A82B04DAD4004717BC /* MapViewController.swift */,
 				FC2511AC2B04EACD004717BC /* MapInteractor.swift */,
 				FC2511AE2B04EAD9004717BC /* MapPresenter.swift */,
-				FC2511AA2B04EA6B004717BC /* MapConfigurator.swift */,
+				FC70BB2E2B20B66300B37CBE /* MapWorker.swift */,
 				FC2511B02B04EAEC004717BC /* MapModels.swift */,
 				836C33902B17629400ECAFB0 /* MapRouter.swift */,
+				FC2511AA2B04EA6B004717BC /* MapConfigurator.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -1198,6 +1199,7 @@
 				FC3752342B170A620000D439 /* EditVideoViewController.swift in Sources */,
 				19A169442B17C71C00DB34C0 /* Board.swift in Sources */,
 				194552252B0478B400299768 /* HomeViewController.swift in Sources */,
+				FC70BB2F2B20B66300B37CBE /* MapWorker.swift in Sources */,
 				FC4084C62B1F1C5B00CE4727 /* UploadPostDTO.swift in Sources */,
 				194552222B0478B400299768 /* HomeWorker.swift in Sources */,
 				194C21BD2B1B728600C62645 /* StubAuthManager.swift in Sources */,
@@ -1224,7 +1226,6 @@
 				8321A2F12B1E1026000A12AF /* ReportModels.swift in Sources */,
 				FC2511A62B049020004717BC /* SignUpConfigurator.swift in Sources */,
 				194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */,
-				FC767FAA2B126D080088CF9B /* LOAnnotation.swift in Sources */,
 				19A169472B17D12500DB34C0 /* MockTagPlayListWorker.swift in Sources */,
 				193686722B15BCA7008902CD /* UserEndPointFactory.swift in Sources */,
 				194551F22B037F2D00299768 /* LoginPresenter.swift in Sources */,
@@ -1283,10 +1284,10 @@
 				FC68E29D2B02326A001AABFF /* Responsable.swift in Sources */,
 				FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */,
 				FC767F862B1214C10088CF9B /* CheckUserNameDTO.swift in Sources */,
-				836C338D2B15D91F00ECAFB0 /* VideoDTO.swift in Sources */,
 				FC4084C42B1F14F600CE4727 /* UploadPostEndPointFactory.swift in Sources */,
 				FC5BE1232B1490660036366D /* EditProfileConfigurator.swift in Sources */,
 				1945522A2B04883800299768 /* UIView+.swift in Sources */,
+				FC70BB332B20C96200B37CBE /* LOAnnotation.swift in Sources */,
 				FCE52FFA2B0FCB0A002CDB75 /* URLSession+.swift in Sources */,
 				19743C052B06940D001E405A /* PlayerView.swift in Sources */,
 				1915D6E52B1FB82000CE1DD0 /* CheckSignUpDTO.swift in Sources */,

--- a/iOS/Layover/Layover/Models/Board.swift
+++ b/iOS/Layover/Layover/Models/Board.swift
@@ -14,6 +14,6 @@ struct Board {
     let description: String?
     let thumbnailImageURL: URL?
     let videoURL: URL?
-    let latitude: Double?
-    let longitude: Double?
+    let latitude: Double
+    let longitude: Double
 }

--- a/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
@@ -12,7 +12,8 @@ struct BoardDTO: Decodable {
     let id: Int
     let encodedVideoURL: String
     let videoThumbnailURL: String
-    let latitude, longitude, title, content: String
+    let latitude, longitude: Double
+    let title, content: String
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -30,8 +31,8 @@ extension BoardDTO {
             description: content,
             thumbnailImageURL: URL(string: videoThumbnailURL),
             videoURL: URL(string: encodedVideoURL),
-            latitude: Double(latitude),
-            longitude: Double(longitude)
+            latitude: latitude,
+            longitude: longitude
         )
     }
 }

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/PostEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/PostEndPointFactory.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol PostEndPointFactory {
     func makeHomePostListEndPoint() -> EndPoint<Response<[PostDTO]>>
+    func makeMapPostListEndPoint(latitude: Double, longitude: Double) -> EndPoint<Response<[PostDTO]>>
     func makeTagSearchPostListEndPoint(by tag: String) -> EndPoint<Response<[PostDTO]>>
 }
 
@@ -18,6 +19,18 @@ final class DefaultPostEndPointFactory: PostEndPointFactory {
         return EndPoint(
             path: "/board/home",
             method: .GET
+        )
+    }
+
+    func makeMapPostListEndPoint(latitude: Double, longitude: Double) -> EndPoint<Response<[PostDTO]>> {
+        var queryParameters = [String: String]()
+        queryParameters.updateValue(String(latitude), forKey: "latitude")
+        queryParameters.updateValue(String(longitude), forKey: "longitude")
+
+        return EndPoint(
+            path: "/board/map",
+            method: .GET,
+            queryParameters: queryParameters
         )
     }
 

--- a/iOS/Layover/Layover/Scenes/Map/LOAnnotation.swift
+++ b/iOS/Layover/Layover/Scenes/Map/LOAnnotation.swift
@@ -9,11 +9,17 @@
 import MapKit
 
 final class LOAnnotation: NSObject, MKAnnotation {
+
     @objc dynamic var coordinate: CLLocationCoordinate2D
+    let boardID: Int
     let thumbnailImageData: Data
 
-    init(coordinate: CLLocationCoordinate2D, thumbnailImageData: Data) {
+    init(coordinate: CLLocationCoordinate2D,
+         boardID: Int,
+         thumbnailImageData: Data) {
         self.coordinate = coordinate
+        self.boardID = boardID
         self.thumbnailImageData = thumbnailImageData
     }
+
 }

--- a/iOS/Layover/Layover/Scenes/Map/LOAnnotation.swift
+++ b/iOS/Layover/Layover/Scenes/Map/LOAnnotation.swift
@@ -10,10 +10,10 @@ import MapKit
 
 final class LOAnnotation: NSObject, MKAnnotation {
     @objc dynamic var coordinate: CLLocationCoordinate2D
-    let thumbnailURL: URL
+    let thumbnailImageData: Data
 
-    init(coordinate: CLLocationCoordinate2D, thumbnailURL: URL) {
+    init(coordinate: CLLocationCoordinate2D, thumbnailImageData: Data) {
         self.coordinate = coordinate
-        self.thumbnailURL = thumbnailURL
+        self.thumbnailImageData = thumbnailImageData
     }
 }

--- a/iOS/Layover/Layover/Scenes/Map/MapConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapConfigurator.swift
@@ -20,11 +20,13 @@ final class MapConfigurator: Configurator {
         let interactor = MapInteractor()
         let presenter = MapPresenter()
         let router = MapRouter()
+        let worker = MapWorker()
         let videoFileWorker = VideoFileWorker()
 
         router.viewController = viewController
         viewController.interactor = interactor
         interactor.presenter = presenter
+        interactor.worker = worker
         interactor.videoFileWorker = videoFileWorker
         presenter.viewController = viewController
         viewController.router = router

--- a/iOS/Layover/Layover/Scenes/Map/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapModels.swift
@@ -68,23 +68,6 @@ enum MapModels {
 
     // MARK: - Move To Playback Scene
 
-    enum MoveToPlaybackScene {
-        struct Request {
-            let index: Int
-            let videos: [Post]
-        }
-
-        struct Response {
-            let index: Int
-            let videos: [Post]
-        }
-
-        struct ViewModel {
-            let index: Int
-            let videos: [Post]
-        }
-    }
-
     enum PlayPosts {
         struct Request {
             let selectedIndex: Int

--- a/iOS/Layover/Layover/Scenes/Map/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapModels.swift
@@ -18,6 +18,7 @@ enum MapModels {
     }
 
     struct DisplayedPost: Hashable {
+        let boardID: Int
         let thumbnailImageData: Data
         let videoURL: URL
         let latitude: Double

--- a/iOS/Layover/Layover/Scenes/Map/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapModels.swift
@@ -10,6 +10,20 @@ import Foundation
 
 enum MapModels {
 
+    struct Post {
+        let member: Member
+        let board: Board
+        let tag: [String]
+        let thumnailImageData: Data
+    }
+
+    struct DisplayedPost: Hashable {
+        let thumbnailImageData: Data
+        let videoURL: URL
+        let latitude: Double
+        let longitude: Double
+    }
+
     // MARK: - Fetch Video Use Cases
     enum FetchVideo {
         struct Request {
@@ -17,7 +31,7 @@ enum MapModels {
             var longitude: Double
         }
 
-        struct Reponse {
+        struct Response {
             var videoURLs: [URL]
         }
 
@@ -28,6 +42,26 @@ enum MapModels {
                 var id = UUID()
                 var videoURL: URL
             }
+        }
+    }
+
+    enum FetchPosts {
+        struct Request {
+            var latitude: Double
+            var longitude: Double
+        }
+
+        struct Response {
+            var posts: [Post]
+        }
+
+        struct ViewModel {
+            var displayedPosts: [DisplayedPost]
+
+//            struct VideoDataSource: Hashable {
+//                var id = UUID()
+//                var videoURL: URL
+//            }
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
@@ -40,7 +40,8 @@ final class MapPresenter: MapPresentationLogic {
         let displayedPost = response.posts
             .map { post -> Models.DisplayedPost? in
                 if let videoURL = post.board.videoURL {
-                    return .init(thumbnailImageData: post.thumnailImageData,
+                    return .init(boardID: post.board.identifier,
+                                 thumbnailImageData: post.thumnailImageData,
                                  videoURL: videoURL,
                                  latitude: post.board.latitude,
                                  longitude: post.board.longitude)

--- a/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
@@ -11,7 +11,6 @@ import Foundation
 protocol MapPresentationLogic {
     func presentCurrentLocation()
     func presentDefaultLocation()
-    func presentFetchedVideos(with response: MapModels.FetchVideo.Response)
     func presentFetchedPosts(with response: MapModels.FetchPosts.Response)
     func presentPlaybackScene()
 }
@@ -29,11 +28,6 @@ final class MapPresenter: MapPresentationLogic {
 
     func presentDefaultLocation() {
         // TODO: 위치 관련 기능 사용 불가, 디폴트 위치로 이동
-    }
-
-    func presentFetchedVideos(with response: MapModels.FetchVideo.Response) {
-        let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURL: $0) })
-        viewController?.displayFetchedVideos(viewModel: viewModel)
     }
 
     func presentFetchedPosts(with response: MapModels.FetchPosts.Response) {

--- a/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapPresenter.swift
@@ -11,7 +11,8 @@ import Foundation
 protocol MapPresentationLogic {
     func presentCurrentLocation()
     func presentDefaultLocation()
-    func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse)
+    func presentFetchedVideos(with response: MapModels.FetchVideo.Response)
+    func presentFetchedPosts(with response: MapModels.FetchPosts.Response)
     func presentPlaybackScene()
 }
 
@@ -30,9 +31,26 @@ final class MapPresenter: MapPresentationLogic {
         // TODO: 위치 관련 기능 사용 불가, 디폴트 위치로 이동
     }
 
-    func presentFetchedVideos(with response: MapModels.FetchVideo.Reponse) {
+    func presentFetchedVideos(with response: MapModels.FetchVideo.Response) {
         let viewModel = MapModels.FetchVideo.ViewModel(videoDataSources: response.videoURLs.map { .init(videoURL: $0) })
         viewController?.displayFetchedVideos(viewModel: viewModel)
+    }
+
+    func presentFetchedPosts(with response: MapModels.FetchPosts.Response) {
+        let displayedPost = response.posts
+            .map { post -> Models.DisplayedPost? in
+                if let videoURL = post.board.videoURL {
+                    return .init(thumbnailImageData: post.thumnailImageData,
+                                 videoURL: videoURL,
+                                 latitude: post.board.latitude,
+                                 longitude: post.board.longitude)
+                } else {
+                    return nil
+                }
+            }.compactMap { $0 }
+
+        let viewModel = Models.FetchPosts.ViewModel(displayedPosts: displayedPost)
+        viewController?.dispalyFetchedPosts(viewModel: viewModel)
     }
 
     func presentPlaybackScene() {

--- a/iOS/Layover/Layover/Scenes/Map/MapRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapRouter.swift
@@ -32,7 +32,7 @@ final class MapRouter: MapRoutingLogic, MapDataPassing {
               let destination = playbackViewController.router?.dataStore
         else { return }
         destination.parentView = .other
-        destination.index = source.index
+        destination.index = source.postPlayStartIndex
         destination.posts = source.posts
         viewController?.navigationController?.pushViewController(playbackViewController, animated: true)
     }

--- a/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
@@ -96,9 +96,7 @@ final class MapViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         interactor?.checkLocationAuthorizationStatus()
-        print(mapView.centerCoordinate)
-        interactor?.fetchPosts(latitude: mapView.centerCoordinate.latitude,
-                               longitude: mapView.centerCoordinate.longitude)
+        interactor?.fetchPosts()
         setCollectionViewDataSource()
         setDelegation()
     }
@@ -197,8 +195,8 @@ final class MapViewController: BaseViewController {
 
     @objc private func searchButtonDidTap() {
         searchButton.isHidden = true
-        interactor?.fetchPosts(latitude: mapView.centerCoordinate.latitude,
-                               longitude: mapView.centerCoordinate.longitude)
+        interactor?.fetchPost(latitude: mapView.centerCoordinate.latitude,
+                              longitude: mapView.centerCoordinate.longitude)
     }
 
     @objc private func currentLocationButtonDidTap() {

--- a/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
@@ -10,7 +10,6 @@ import MapKit
 import UIKit
 
 protocol MapDisplayLogic: AnyObject {
-    func displayFetchedVideos(viewModel: MapModels.FetchVideo.ViewModel)
     func dispalyFetchedPosts(viewModel: MapModels.FetchPosts.ViewModel)
     func routeToPlayback()
 }
@@ -67,7 +66,8 @@ final class MapViewController: BaseViewController {
     private lazy var carouselDatasource = UICollectionViewDiffableDataSource<UUID, Models.DisplayedPost>(collectionView: carouselCollectionView) { collectionView, indexPath, item in
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MapCarouselCollectionViewCell.identifier,
                                                             for: indexPath) as? MapCarouselCollectionViewCell else { return UICollectionViewCell() }
-        cell.configure(url: item.videoURL)
+        cell.setVideo(url: item.videoURL)
+        cell.configure(thumbnailImageData: item.thumbnailImageData)
         return cell
     }
 
@@ -164,10 +164,10 @@ final class MapViewController: BaseViewController {
                 item.transform = CGAffineTransform(scaleX: scale, y: scale)
                 let cell = self?.carouselCollectionView.cellForItem(at: item.indexPath) as? MapCarouselCollectionViewCell
                 if scale >= maximumZoomScale * 0.9 {
-                    cell?.loopingPlayerView.play()
+                    cell?.play()
                     self?.selectAnnotation(at: item.indexPath)
                 } else {
-                    cell?.loopingPlayerView.pause()
+                    cell?.pause()
                 }
             }
         }
@@ -199,7 +199,6 @@ final class MapViewController: BaseViewController {
             .first
         guard let focusedAnnotaion else { return }
         mapView.setCenter(focusedAnnotaion.coordinate, animated: true)
-        mapView.selectAnnotation(focusedAnnotaion, animated: true)
     }
 
     @objc private func searchButtonDidTap() {
@@ -285,13 +284,6 @@ extension MapViewController: VideoPickerDelegate {
 // MARK: - MapDisplayLogic
 
 extension MapViewController: MapDisplayLogic {
-
-    func displayFetchedVideos(viewModel: ViewModel) {
-        var snapshot: NSDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<UUID, ViewModel.VideoDataSource>()
-        snapshot.appendSections([UUID()])
-        snapshot.appendItems(viewModel.videoDataSources)
-//        carouselDatasource.apply(snapshot)
-    }
 
     func dispalyFetchedPosts(viewModel: MapModels.FetchPosts.ViewModel) {
         displayedPost = viewModel.displayedPosts

--- a/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
@@ -198,6 +198,7 @@ final class MapViewController: BaseViewController {
             .filter { $0.boardID == focusedPost.boardID }
             .first
         guard let focusedAnnotaion else { return }
+        mapView.setCenter(focusedAnnotaion.coordinate, animated: true)
         mapView.selectAnnotation(focusedAnnotaion, animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/Map/MapWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapWorker.swift
@@ -1,0 +1,50 @@
+//
+//  MapWorker.swift
+//  Layover
+//
+//  Created by kong on 2023/12/06.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+protocol MapWorkerProtocol {
+    func fetchPosts(latitude: Double, longitude: Double) async -> [MapModels.Post]?
+}
+
+final class MapWorker: MapWorkerProtocol {
+
+    // MARK: - Properties
+
+    typealias Models = MapModels
+    private let provider: ProviderType
+    private let postEndPointFactory: PostEndPointFactory
+
+    // MARK: - Methods
+
+    init(provider: ProviderType = Provider(),
+         postEndPointFactory: PostEndPointFactory = DefaultPostEndPointFactory()) {
+        self.provider = provider
+        self.postEndPointFactory = postEndPointFactory
+    }
+
+    func fetchPosts(latitude: Double, longitude: Double) async -> [Models.Post]? {
+        let endPoint = postEndPointFactory.makeMapPostListEndPoint(latitude: latitude, longitude: longitude)
+        do {
+            let response = try await provider.request(with: endPoint)
+            guard var data = response.data else { return nil }
+
+            let posts = try await data.asyncMap { postDTO -> Models.Post in
+                let thumnailImageData = try await provider.request(url: postDTO.board.videoThumbnailURL)
+                return .init(member: postDTO.member.toDomain(),
+                             board: postDTO.board.toDomain(),
+                             tag: postDTO.tag,
+                             thumnailImageData: thumnailImageData)
+            }
+            return posts
+        } catch {
+            return nil
+        }
+    }
+
+}

--- a/iOS/Layover/Layover/Scenes/Map/MapWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapWorker.swift
@@ -32,10 +32,9 @@ final class MapWorker: MapWorkerProtocol {
         let endPoint = postEndPointFactory.makeMapPostListEndPoint(latitude: latitude, longitude: longitude)
         do {
             let response = try await provider.request(with: endPoint)
-            guard var data = response.data else { return nil }
-
-            let posts = try await data.asyncMap { postDTO -> Models.Post in
-                let thumnailImageData = try await provider.request(url: postDTO.board.videoThumbnailURL)
+            guard let data = response.data else { return nil }
+            let posts = try await data.concurrentMap { postDTO -> Models.Post in
+                let thumnailImageData = try await self.provider.request(url: postDTO.board.videoThumbnailURL)
                 return .init(member: postDTO.member.toDomain(),
                              board: postDTO.board.toDomain(),
                              tag: postDTO.tag,

--- a/iOS/Layover/Layover/Scenes/Map/Views/LOAnnotationView.swift
+++ b/iOS/Layover/Layover/Scenes/Map/Views/LOAnnotationView.swift
@@ -51,7 +51,6 @@ final class LOAnnotationView: MKAnnotationView {
     // MARK: - View Lifecycle
     override func prepareForDisplay() {
         super.prepareForDisplay()
-        setThumbnailImage()
     }
 
     override func layoutSubviews() {
@@ -61,8 +60,8 @@ final class LOAnnotationView: MKAnnotationView {
 
     // MARK: - Methods
 
-    func setThumbnailImage() {
-        self.thumbnailImageView.image = .checkmark
+    func setThumbnailImage(data: Data) {
+        self.thumbnailImageView.image = UIImage(data: data)
     }
 
     private func render() {

--- a/iOS/Layover/Layover/Scenes/Map/Views/MapCarouselCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Map/Views/MapCarouselCollectionViewCell.swift
@@ -11,7 +11,13 @@ import AVFoundation
 
 final class MapCarouselCollectionViewCell: UICollectionViewCell {
 
-    private(set) var loopingPlayerView = LoopingPlayerView()
+    private let loopingPlayerView = LoopingPlayerView()
+
+    private let thumbnailImageView: UIImageView = {
+        let imageView: UIImageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -25,21 +31,42 @@ final class MapCarouselCollectionViewCell: UICollectionViewCell {
         render()
     }
 
-    func configure(url: URL) {
+    func setVideo(url: URL) {
+        loopingPlayerView.disable()
         loopingPlayerView.prepareVideo(with: url,
                                        timeRange: CMTimeRange(start: .zero, duration: CMTime(value: 1800, timescale: 600)))
         loopingPlayerView.player?.isMuted = true
     }
 
+    func configure(thumbnailImageData: Data) {
+        thumbnailImageView.image = UIImage(data: thumbnailImageData)
+    }
+
+    func play() {
+        loopingPlayerView.play()
+        thumbnailImageView.isHidden = true
+    }
+
+    func pause() {
+        loopingPlayerView.pause()
+        thumbnailImageView.isHidden = false
+    }
+
+
     private func setUI() {
         backgroundColor = .background
-        contentView.addSubview(loopingPlayerView)
-        loopingPlayerView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubviews(loopingPlayerView, thumbnailImageView)
+        contentView.subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         NSLayoutConstraint.activate([
             loopingPlayerView.topAnchor.constraint(equalTo: contentView.topAnchor),
             loopingPlayerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             loopingPlayerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            loopingPlayerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            thumbnailImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.

- 지도 탭에 반경 내 게시물들을 보여주는 api를 연결했습니다.

### 어노테이션 선택 → 해당 영상으로 스크롤
https://github.com/boostcampwm2023/iOS09-Layover/assets/70168249/1ce3f078-8b61-4213-bac1-5114313b38f0

### 영상 스크롤 → 어노테이션 포커싱
https://github.com/boostcampwm2023/iOS09-Layover/assets/70168249/e60c000a-3328-4e88-88ef-3df44924d552

- 현재 어노테이션으로 포커싱은 하고있으나, selection 문제로 인해서 하이라이트는 안되는 상황입니다..
- 임의로 어노테이션을 select을 하는 순간 로직이 꼬여서 좀 더 공부해서 개선해보겠습니다 !

### 썸네일 concurrent하게 다운로드
- 이 과정에서 thumbnailImage의 타입이 Data인 모델이 필요했습니다.
- 근데 공통으로 쓰고있는 Post모델은 URL 타입이어서 전부 바꿀까 하다가
- 우선은 MapModels 내부에 Post를 만들어두고 썼습니다.. ! Worker에서 data로 변환해줘서 interactor에 뿌리는게 다 괜찮으시면 나중에 공통 모델을 바꾸어야 할 것 같습니다.
```swift
            let posts = try await data.concurrentMap { postDTO -> Models.Post in
                let thumnailImageData = try await self.provider.request(url: postDTO.board.videoThumbnailURL)
                return .init(member: postDTO.member.toDomain(),
                             board: postDTO.board.toDomain(),
                             tag: postDTO.tag,
                             thumnailImageData: thumnailImageData)
            }
```

#### Linked Issue
close #226 
