### PR TITLE
feat: 프로필 변경 화면 VIP 구현

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		198167A32B20583D0032F563 /* SettingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1981679E2B20583D0032F563 /* SettingModels.swift */; };
 		198167A42B20583D0032F563 /* SettingInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1981679F2B20583D0032F563 /* SettingInteractor.swift */; };
 		198167A62B20593B0032F563 /* SettingConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198167A52B20593B0032F563 /* SettingConfigurator.swift */; };
+		198167A82B20DD670032F563 /* PresignedURLDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198167A72B20DD670032F563 /* PresignedURLDTO.swift */; };
 		19A169232B176C5F00DB34C0 /* TagPlayListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A1691D2B176C5F00DB34C0 /* TagPlayListPresenter.swift */; };
 		19A169242B176C5F00DB34C0 /* TagPlayListWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A1691E2B176C5F00DB34C0 /* TagPlayListWorker.swift */; };
 		19A169252B176C5F00DB34C0 /* TagPlayListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19A1691F2B176C5F00DB34C0 /* TagPlayListRouter.swift */; };
@@ -268,6 +269,7 @@
 		1981679E2B20583D0032F563 /* SettingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingModels.swift; sourceTree = "<group>"; };
 		1981679F2B20583D0032F563 /* SettingInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingInteractor.swift; sourceTree = "<group>"; };
 		198167A52B20593B0032F563 /* SettingConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingConfigurator.swift; sourceTree = "<group>"; };
+		198167A72B20DD670032F563 /* PresignedURLDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresignedURLDTO.swift; sourceTree = "<group>"; };
 		19A1691D2B176C5F00DB34C0 /* TagPlayListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagPlayListPresenter.swift; sourceTree = "<group>"; };
 		19A1691E2B176C5F00DB34C0 /* TagPlayListWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagPlayListWorker.swift; sourceTree = "<group>"; };
 		19A1691F2B176C5F00DB34C0 /* TagPlayListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagPlayListRouter.swift; sourceTree = "<group>"; };
@@ -613,12 +615,11 @@
 				19A169372B17BCA800DB34C0 /* PostDTO.swift */,
 				19A169392B17BCC400DB34C0 /* MemberDTO.swift */,
 				19A1693B2B17BD1C00DB34C0 /* BoardDTO.swift */,
-				836C338C2B15D91F00ECAFB0 /* VideoDTO.swift */,
-				836C338E2B160CC700ECAFB0 /* MemberDTO.swift */,
 				8321A2FE2B1E428C000A12AF /* ReportDTO.swift */,
 				FC4084C52B1F1C5B00CE4727 /* UploadPostDTO.swift */,
 				FC4084C92B1F291200CE4727 /* UploadVideoDTO.swift */,
 				1915D6E42B1FB82000CE1DD0 /* CheckSignUpDTO.swift */,
+				198167A72B20DD670032F563 /* PresignedURLDTO.swift */,
 			);
 			path = DTOs;
 			sourceTree = "<group>";
@@ -1223,7 +1224,6 @@
 				FCEE0FF22B036B6000195BBE /* LOButton.swift in Sources */,
 				FC5BE1212B148D170036366D /* EditProfileInteractor.swift in Sources */,
 				FC930E7C2B0CD80800AA48E3 /* ProfileConfigurator.swift in Sources */,
-				836C33992B1843BE00ECAFB0 /* SettingScenePresenter.swift in Sources */,
 				8321A2F12B1E1026000A12AF /* ReportModels.swift in Sources */,
 				FC2511A62B049020004717BC /* SignUpConfigurator.swift in Sources */,
 				194552392B05230E00299768 /* HomeCarouselCollectionViewCell.swift in Sources */,
@@ -1287,7 +1287,6 @@
 				FC68E29D2B02326A001AABFF /* Responsable.swift in Sources */,
 				FC2511A02B045C0A004717BC /* SignUpInteractor.swift in Sources */,
 				FC767F862B1214C10088CF9B /* CheckUserNameDTO.swift in Sources */,
-				836C338D2B15D91F00ECAFB0 /* VideoDTO.swift in Sources */,
 				FC4084C42B1F14F600CE4727 /* UploadPostEndPointFactory.swift in Sources */,
 				FC5BE1232B1490660036366D /* EditProfileConfigurator.swift in Sources */,
 				1945522A2B04883800299768 /* UIView+.swift in Sources */,
@@ -1302,7 +1301,7 @@
 				836C33912B17629400ECAFB0 /* MapRouter.swift in Sources */,
 				19C7AFCE2B02410F003B35F2 /* AuthManager.swift in Sources */,
 				836C339D2B1843BE00ECAFB0 /* SettingViewController.swift in Sources */,
-				836C339D2B1843BE00ECAFB0 /* SettingSceneViewController.swift in Sources */,
+				836C339D2B1843BE00ECAFB0 /* SettingViewController.swift in Sources */,
 				8321A2FF2B1E428C000A12AF /* ReportDTO.swift in Sources */,
 				FC9BB82C2B094E5500EB72A9 /* UICollectionViewLayout+.swift in Sources */,
 				194552232B0478B400299768 /* HomeRouter.swift in Sources */,
@@ -1346,6 +1345,7 @@
 				FC68E2A52B0233D3001AABFF /* Provider.swift in Sources */,
 				FC930E7E2B0CDB2900AA48E3 /* ThumbnailCollectionViewCell.swift in Sources */,
 				194552112B03AF2B00299768 /* MainTabBarConfigurator.swift in Sources */,
+				198167A82B20DD670032F563 /* PresignedURLDTO.swift in Sources */,
 				8321A2F72B1E14A1000A12AF /* LOPopUpView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -1042,15 +1042,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FC7E45602AFEB62C004F155A /* Build configuration list for PBXNativeTarget "Layover" */;
 			buildPhases = (
+				FC182BD22B1D90C700051CBC /* SwiftLint Script */,
 				FC7E45322AFEB623004F155A /* Sources */,
 				FC7E45332AFEB623004F155A /* Frameworks */,
 				FC7E45342AFEB623004F155A /* Resources */,
-				FC182BD22B1D90C700051CBC /* SwiftLint Script */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				194552192B03DD7A00299768 /* PBXTargetDependency */,
 			);
 			name = Layover;
 			packageProductDependencies = (
@@ -1377,10 +1376,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		194552192B03DD7A00299768 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 194552182B03DD7A00299768 /* SwiftLintPlugin */;
-		};
 		FC7E454E2AFEB62C004F155A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FC7E45352AFEB623004F155A /* Layover */;
@@ -1668,14 +1663,6 @@
 				kind = branch;
 			};
 		};
-		FC7E456D2AFF6E44004F155A /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1683,11 +1670,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 194551FB2B03863B00299768 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDK;
-		};
-		194552182B03DD7A00299768 /* SwiftLintPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FC7E456D2AFF6E44004F155A /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintPlugin";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/Layover/Layover.xcodeproj/xcshareddata/xcschemes/Layover.xcscheme
+++ b/iOS/Layover/Layover.xcodeproj/xcshareddata/xcschemes/Layover.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC7E45352AFEB623004F155A"
+               BuildableName = "Layover.app"
+               BlueprintName = "Layover"
+               ReferencedContainer = "container:Layover.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC7E454B2AFEB62B004F155A"
+               BuildableName = "LayoverTests.xctest"
+               BlueprintName = "LayoverTests"
+               ReferencedContainer = "container:Layover.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC7E45352AFEB623004F155A"
+            BuildableName = "Layover.app"
+            BlueprintName = "Layover"
+            ReferencedContainer = "container:Layover.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC7E45352AFEB623004F155A"
+            BuildableName = "Layover.app"
+            BlueprintName = "Layover"
+            ReferencedContainer = "container:Layover.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
@@ -21,7 +21,7 @@ struct MemberDTO: Decodable {
 
 extension MemberDTO {
     func toDomain() -> Member {
-        var imageURL: URL? = nil
+        var imageURL: URL?
         if let profileImageURL {
             imageURL = URL(string: profileImageURL)
         }

--- a/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/MemberDTO.swift
@@ -11,7 +11,7 @@ import Foundation
 struct MemberDTO: Decodable {
     let id: Int
     let username, introduce: String
-    let profileImageURL: String
+    let profileImageURL: String?
 
     enum CodingKeys: String, CodingKey {
         case id, username, introduce
@@ -21,11 +21,16 @@ struct MemberDTO: Decodable {
 
 extension MemberDTO {
     func toDomain() -> Member {
+        var imageURL: URL? = nil
+        if let profileImageURL {
+            imageURL = URL(string: profileImageURL)
+        }
+        
         return Member(
             identifier: id,
             username: username,
             introduce: introduce,
-            profileImageURL: URL(string: profileImageURL)
+            profileImageURL: imageURL
         )
     }
 }

--- a/iOS/Layover/Layover/Network/DTOs/PresignedURLDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/PresignedURLDTO.swift
@@ -1,0 +1,17 @@
+//
+//  PresignedURLDTO.swift
+//  Layover
+//
+//  Created by 김인환 on 12/7/23.
+//  Copyright © 2023 CodeBomber. All rights reserved.
+//
+
+import Foundation
+
+struct PresignedURLDTO: Decodable {
+    let preSignedURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case preSignedURL = "preSignedUrl"
+    }
+}

--- a/iOS/Layover/Layover/Network/DTOs/UploadVideoDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/UploadVideoDTO.swift
@@ -8,14 +8,6 @@
 
 import Foundation
 
-struct UploadVideoDTO: Decodable {
-    let preSignedURL: String
-
-    enum CodingKeys: String, CodingKey {
-        case preSignedURL = "preSignedUrl"
-    }
-}
-
 struct UploadVideoRequestDTO: Encodable {
     let boardID: Int
     let filetype: String

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/UploadPostEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/UploadPostEndPointFactory.swift
@@ -14,7 +14,7 @@ protocol UploadPostEndPointFactory {
                                 latitude: Double,
                                 longitude: Double,
                                 tag: [String]) -> EndPoint<Response<UploadPostDTO>>
-    func makeUploadVideoEndPoint(boardID: Int, fileType: String) -> EndPoint<Response<UploadVideoDTO>>
+    func makeUploadVideoEndPoint(boardID: Int, fileType: String) -> EndPoint<Response<PresignedURLDTO>>
 }
 
 final class DefaultUploadPostEndPointFactory: UploadPostEndPointFactory {
@@ -33,7 +33,7 @@ final class DefaultUploadPostEndPointFactory: UploadPostEndPointFactory {
                                                              tag: tag))
     }
 
-    func makeUploadVideoEndPoint(boardID: Int, fileType: String) -> EndPoint<Response<UploadVideoDTO>> {
+    func makeUploadVideoEndPoint(boardID: Int, fileType: String) -> EndPoint<Response<PresignedURLDTO>> {
         return EndPoint(path: "/board/presigned-url",
                         method: .POST,
                         bodyParameters: UploadVideoRequestDTO(boardID: boardID,

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
@@ -92,7 +92,7 @@ final class DefaultUserEndPointFactory: UserEndPointFactory {
 
     func makeFetchUserProfilePresignedURL(of fileType: String) -> EndPoint<Response<PresignedURLDTO>> {
         var bodyParameters = [String: String]()
-        bodyParameters.updateValue(fileType, forKey: "fileType")
+        bodyParameters.updateValue(fileType, forKey: "filetype")
 
         return EndPoint(
             path: "/member/profile-image/presigned-url",

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
@@ -15,6 +15,7 @@ protocol UserEndPointFactory {
     func makeUserWithDrawEndPoint() -> EndPoint<Response<NicknameDTO>>
     func makeUserInformationEndPoint(with id: Int?) -> EndPoint<Response<MemberDTO>>
     func makeUserPostsEndPoint(at page: Int, of id: Int?) -> EndPoint<Response<[PostDTO]>>
+    func makeFetchUserProfilePresignedURL(of fileType: String) -> EndPoint<Response<PresignedURLDTO>>
 }
 
 final class DefaultUserEndPointFactory: UserEndPointFactory {
@@ -75,7 +76,6 @@ final class DefaultUserEndPointFactory: UserEndPointFactory {
     }
 
     func makeUserPostsEndPoint(at page: Int, of id: Int? = nil) -> EndPoint<Response<[PostDTO]>> {
-
         var queryParameters = [String: String]()
         queryParameters.updateValue(String(page), forKey: "page")
 
@@ -87,6 +87,17 @@ final class DefaultUserEndPointFactory: UserEndPointFactory {
             path: "/board/profile",
             method: .GET,
             queryParameters: queryParameters
+        )
+    }
+
+    func makeFetchUserProfilePresignedURL(of fileType: String) -> EndPoint<Response<PresignedURLDTO>> {
+        var bodyParameters = [String: String]()
+        bodyParameters.updateValue(fileType, forKey: "fileType")
+
+        return EndPoint(
+            path: "/member/profile-image/presigned-url",
+            method: .POST,
+            bodyParameters: bodyParameters
         )
     }
 }

--- a/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
+++ b/iOS/Layover/Layover/Network/EndPoint/Factories/UserEndPointFactory.swift
@@ -15,6 +15,7 @@ protocol UserEndPointFactory {
     func makeUserWithDrawEndPoint() -> EndPoint<Response<NicknameDTO>>
     func makeUserInformationEndPoint(with id: Int?) -> EndPoint<Response<MemberDTO>>
     func makeUserPostsEndPoint(at page: Int, of id: Int?) -> EndPoint<Response<[PostDTO]>>
+    func makeUserProfileImageDefaultEndPoint() -> EndPoint<Response<Data>>
     func makeFetchUserProfilePresignedURL(of fileType: String) -> EndPoint<Response<PresignedURLDTO>>
 }
 
@@ -87,6 +88,13 @@ final class DefaultUserEndPointFactory: UserEndPointFactory {
             path: "/board/profile",
             method: .GET,
             queryParameters: queryParameters
+        )
+    }
+
+    func makeUserProfileImageDefaultEndPoint() -> EndPoint<Response<Data>> {
+        return EndPoint(
+            path: "/member/profile-image/default",
+            method: .POST
         )
     }
 

--- a/iOS/Layover/Layover/Network/Provider/Provider.swift
+++ b/iOS/Layover/Layover/Network/Provider/Provider.swift
@@ -14,10 +14,10 @@ protocol ProviderType {
     func request(url: String) async throws -> Data
     func upload(data: Data, to presignedURL: String, method: HTTPMethod) async throws -> Data
     func upload(fromFile: URL,
-                          to url: String,
-                          method: HTTPMethod,
-                          sessionTaskDelegate: URLSessionTaskDelegate?,
-                          delegateQueue: OperationQueue?) async throws -> Data
+                to url: String,
+                method: HTTPMethod,
+                sessionTaskDelegate: URLSessionTaskDelegate?,
+                delegateQueue: OperationQueue?) async throws -> Data
 }
 
 extension ProviderType {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileConfigurator.swift
@@ -20,7 +20,7 @@ final class EditProfileConfigurator: Configurator {
         let viewController = viewController
         let interactor = EditProfileInteractor()
         let presenter = EditProfilePresenter()
-        let worker = MockUserWorker()
+        let worker = UserWorker()
         let router = EditProfileRouter()
 
         router.viewController = viewController

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -10,7 +10,7 @@ import Foundation
 import OSLog
 
 protocol EditProfileBusinessLogic {
-    func fetchProfile(with request: EditProfileModels.FetchProfile.Request)
+    func setProfile(with request: EditProfileModels.SetProfile.Request)
     func changeProfile(with request: EditProfileModels.ChangeProfile.Request)
     func checkDuplication(with request: EditProfileModels.CheckNicknameDuplication.Request)
     @discardableResult
@@ -44,8 +44,8 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
 
     // MARK: - Use Case
 
-    func fetchProfile(with request: EditProfileModels.FetchProfile.Request) {
-        presenter?.presentProfile(with: EditProfileModels.FetchProfile.Response(nickname: nickname,
+    func setProfile(with request: EditProfileModels.SetProfile.Request) {
+        presenter?.presentProfile(with: EditProfileModels.SetProfile.Response(nickname: nickname,
                                                                                 introduce: introduce,
                                                                                 profileImageData: profileImageData))
     }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -113,6 +113,7 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
             await MainActor.run {
                 presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
             }
+            profileImageData = imageData
             return false
         }
 
@@ -144,7 +145,13 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
                     return false
                 }
             } else { // 이미지 변경이 없는 경우 이미지 삭제 시도
-                _ = await userWorker?.fetchImagePresignedURL(with: "jpeg")
+                guard await userWorker?.fetchImagePresignedURL(with: "jpeg") != nil else {
+                    await MainActor.run {
+                        presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
+                    }
+                    return false
+                }
+                profileImageData = nil
             }
 
             await MainActor.run {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -146,7 +146,7 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
                     return false
                 }
             } else { // 이미지 변경이 없는 경우 이미지 삭제 시도
-                guard await userWorker?.fetchImagePresignedURL(with: "jpeg") != nil else {
+                guard await userWorker?.setProfileImageDefault() == true else {
                     await MainActor.run {
                         presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
                     }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -138,7 +138,8 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
 
             // 이미지 변경 시도
             if let profileImageData = request.profileImageData, let profileImageExtension = request.profileImageExtension {
-                guard await profileImageEditRequest(into: profileImageData, fileExtension: profileImageExtension) else {
+                let imageExtension = profileImageExtension == "jpg" ? "jpeg" : profileImageExtension // 서버에서는 jpeg로 받음
+                guard await profileImageEditRequest(into: profileImageData, fileExtension: imageExtension) else {
                     await MainActor.run {
                         presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
                     }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -60,7 +60,8 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
 
             let canCheckNicknameDuplication = changedNickname == nickname ? false : nicknameState == .valid
 
-            response = Models.ChangeProfile.Response(nicknameAlertDescription: nicknameState != .valid ? nicknameState.description : nil,
+            response = Models.ChangeProfile.Response(nicknameState: nicknameState,
+                                                     nicknameAlertDescription: nicknameState != .valid ? nicknameState.description : nil,
                                                      introduceAlertDescription: nil,
                                                      canCheckNicknameDuplication: canCheckNicknameDuplication,
                                                      canEditProfile: false)
@@ -74,7 +75,8 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
 
             let introduceAlertDescription = introduce == changedIntroduce || introduceState == .valid ? nil : introduceState.description
 
-            response = Models.ChangeProfile.Response(nicknameAlertDescription: nil,
+            response = Models.ChangeProfile.Response(nicknameState: nicknameState,
+                                                     nicknameAlertDescription: nil,
                                                      introduceAlertDescription: introduceAlertDescription,
                                                      canCheckNicknameDuplication: nil,
                                                      canEditProfile: canEditProfile)
@@ -83,7 +85,8 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
             let canEditProfile = didCheckedNicknameDuplicate
             && nicknameState == .valid
             && introduceState == .valid
-            response = Models.ChangeProfile.Response(nicknameAlertDescription: nil,
+            response = Models.ChangeProfile.Response(nicknameState: nicknameState,
+                                                     nicknameAlertDescription: nil,
                                                      introduceAlertDescription: nil,
                                                      canCheckNicknameDuplication: nil,
                                                      canEditProfile: canEditProfile)

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -12,49 +12,67 @@ enum EditProfileModels {
 
     enum FetchProfile {
         struct Request {
-
         }
 
-        struct Reponse {
-            var nickname: String?
-            var introduce: String?
-            var profileImageData: Data?
+        struct Response {
+            let nickname: String?
+            let introduce: String?
+            let profileImageData: Data?
         }
 
         struct ViewModel {
-            var nickname: String?
-            var introduce: String?
-            var profileImageData: Data?
+            let nickname: String?
+            let introduce: String?
+            let profileImageData: Data?
         }
     }
 
-    enum ValidateProfileInfo {
+    enum ChangeProfile {
+        enum IntroduceLengthState: CustomStringConvertible {
+            case overLength
+            case valid
+
+            var description: String {
+                switch self {
+                case .overLength:
+                    return "자기소개는 30자 이내로 입력해주세요."
+                case .valid:
+                    return ""
+                }
+            }
+        }
+
         struct Request {
-            var nickname: String
-            var introduce: String?
-            var profileImageChanged: Bool
+            let nickname: String?
+            let introduce: String?
+            let profileImageData: Data?
+            let validIntroduceLength: Int = 50 // default value
         }
+
         struct Response {
-            var isValid: Bool
-            var nicknameChanged: Bool
+            let newNicknameState: NicknameState
+            let newIntroduceState: IntroduceLengthState
+            let canCheckNicknameDuplication: Bool
+            let canEditProfile: Bool
         }
+
         struct ViewModel {
-            var nicknameAlertDescription: String?
-            var introduceAlertDescription: String?
-            var canCheckDuplication: Bool
-            var canEditProfile: Bool
+            let nicknameAlertDescription: String
+            let introduceAlertDescription: String
+            let canCheckNicknameDuplication: Bool
+            let canEditProfile: Bool
         }
     }
 
     enum CheckNicknameDuplication {
         struct Request {
-            var nickname: String
+            let nickname: String
         }
         struct Response {
-            var isValid: Bool
+            let isValid: Bool
         }
         struct ViewModel {
-            var isValidNickname: Bool
+            let isValidNickname: Bool
             var alertDescription: String {
                 isValidNickname ? "사용가능한 닉네임입니다." : "사용중인 닉네임입니다."
             }
@@ -63,15 +81,15 @@ enum EditProfileModels {
 
     enum EditProfile {
         struct Request {
-            var nickname: String
-            var introduce: String?
-            var profileImage: Data?
+            let nickname: String
+            let introduce: String?
+            let profileImageURL: URL?
         }
 
         struct Response {
-            var nickname: String
-            var introduce: String?
-            var profileImgaeURL: URL?
+            let nickname: String
+            let introduce: String?
+            let profileImageURL: URL?
         }
 
         struct ViewModel {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -28,6 +28,8 @@ enum EditProfileModels {
     }
 
     enum ChangeProfile {
+        static let introduceLengthLimit = 30
+
         enum IntroduceLengthState: CustomStringConvertible {
             case overLength
             case valid
@@ -35,31 +37,35 @@ enum EditProfileModels {
             var description: String {
                 switch self {
                 case .overLength:
-                    return "자기소개는 30자 이내로 입력해주세요."
+                    return "자기소개는 \(introduceLengthLimit)자 이내로 입력해주세요."
                 case .valid:
                     return ""
                 }
             }
         }
 
+        enum ChangedProfileComponent {
+            case nickname(String?)
+            case introduce(String?)
+            case profileImage(Data?)
+        }
+
         struct Request {
-            let nickname: String?
-            let introduce: String?
-            let profileImageData: Data?
-            let validIntroduceLength: Int = 50 // default value
+            let changedProfileComponent: ChangedProfileComponent
+            let validIntroduceLength: Int = introduceLengthLimit
         }
 
         struct Response {
-            let newNicknameState: NicknameState
-            let newIntroduceState: IntroduceLengthState
-            let canCheckNicknameDuplication: Bool
+            let nicknameAlertDescription: String?
+            let introduceAlertDescription: String?
+            let canCheckNicknameDuplication: Bool?
             let canEditProfile: Bool
         }
 
         struct ViewModel {
-            let nicknameAlertDescription: String
-            let introduceAlertDescription: String
-            let canCheckNicknameDuplication: Bool
+            let nicknameAlertDescription: String?
+            let introduceAlertDescription: String?
+            let canCheckNicknameDuplication: Bool?
             let canEditProfile: Bool
         }
     }
@@ -70,9 +76,11 @@ enum EditProfileModels {
         }
         struct Response {
             let isValid: Bool
+            let canEditProfile: Bool
         }
         struct ViewModel {
             let isValidNickname: Bool
+            let canEditProfile: Bool
             var alertDescription: String {
                 isValidNickname ? "사용가능한 닉네임입니다." : "사용중인 닉네임입니다."
             }
@@ -83,17 +91,14 @@ enum EditProfileModels {
         struct Request {
             let nickname: String
             let introduce: String?
-            let profileImageURL: URL?
+            let profileImageData: Data?
+            let profileImageExtension: String?
         }
 
         struct Response {
-            let nickname: String
-            let introduce: String?
-            let profileImageURL: URL?
         }
 
         struct ViewModel {
-
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -56,6 +56,7 @@ enum EditProfileModels {
         }
 
         struct Response {
+            let nicknameState: NicknameState
             let nicknameAlertDescription: String?
             let introduceAlertDescription: String?
             let canCheckNicknameDuplication: Bool?
@@ -63,6 +64,7 @@ enum EditProfileModels {
         }
 
         struct ViewModel {
+            let nicknameState: NicknameState
             let nicknameAlertDescription: String?
             let introduceAlertDescription: String?
             let canCheckNicknameDuplication: Bool?

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum EditProfileModels {
 
-    enum FetchProfile {
+    enum SetProfile {
         struct Request {
         }
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -96,9 +96,11 @@ enum EditProfileModels {
         }
 
         struct Response {
+            let isSuccess: Bool
         }
 
         struct ViewModel {
+            let toastMessage: String
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol EditProfilePresentationLogic {
-    func presentProfile(with response: EditProfileModels.FetchProfile.Response)
+    func presentProfile(with response: EditProfileModels.SetProfile.Response)
     func presentProfile(with response: EditProfileModels.EditProfile.Response)
     func presentProfileState(with response: EditProfileModels.ChangeProfile.Response)
     func presentNicknameDuplication(with response: EditProfileModels.CheckNicknameDuplication.Response)
@@ -24,8 +24,8 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
 
     // MARK: - Methods
 
-    func presentProfile(with response: Models.FetchProfile.Response) {
-        let viewModel = Models.FetchProfile.ViewModel(nickname: response.nickname,
+    func presentProfile(with response: Models.SetProfile.Response) {
+        let viewModel = Models.SetProfile.ViewModel(nickname: response.nickname,
                                                       introduce: response.introduce,
                                                       profileImageData: response.profileImageData)
         viewController?.displayProfile(with: viewModel)

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
@@ -32,7 +32,8 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
     }
 
     func presentProfile(with response: EditProfileModels.EditProfile.Response) {
-        viewController?.displayProfileEditCompleted(with: Models.EditProfile.ViewModel())
+        let toastMessage = response.isSuccess ? "프로필이 수정되었습니다." : "프로필 수정에 실패했습니다."
+        viewController?.displayProfileEditCompleted(with: Models.EditProfile.ViewModel(toastMessage: toastMessage))
     }
 
     func presentProfileState(with response: Models.ChangeProfile.Response) {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
@@ -9,8 +9,9 @@
 import UIKit
 
 protocol EditProfilePresentationLogic {
-    func presentProfile(with response: EditProfileModels.FetchProfile.Reponse)
-    func presentProfileInfoValidation(with response: EditProfileModels.ValidateProfileInfo.Response)
+    func presentProfile(with response: EditProfileModels.FetchProfile.Response)
+    func presentProfileState(with response: EditProfileModels.ChangeProfile.Response)
+
     func presentNicknameDuplication(with response: EditProfileModels.CheckNicknameDuplication.Response)
 }
 
@@ -21,22 +22,26 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
     typealias Models = EditProfileModels
     weak var viewController: EditProfileDisplayLogic?
 
-    func presentProfile(with response: EditProfileModels.FetchProfile.Reponse) {
+    // MARK: - Methods
+
+    func presentProfile(with response: Models.FetchProfile.Response) {
         let viewModel = Models.FetchProfile.ViewModel(nickname: response.nickname,
                                                       introduce: response.introduce,
                                                       profileImageData: response.profileImageData)
-        viewController?.displayProfile(viewModel: viewModel)
+        viewController?.displayProfile(with: viewModel)
     }
 
-    func presentProfileInfoValidation(with response: EditProfileModels.ValidateProfileInfo.Response) {
-        let viewModel = Models.ValidateProfileInfo.ViewModel(canCheckDuplication: response.nicknameChanged,
-                                                             canEditProfile: response.isValid)
-        viewController?.displayProfileInfoValidation(viewModel: viewModel)
+    func presentProfileState(with response: Models.ChangeProfile.Response) {
+        let viewModel = Models.ChangeProfile.ViewModel(nicknameAlertDescription: response.newNicknameState.description,
+                                                       introduceAlertDescription: response.newIntroduceState.description,
+                                                       canCheckNicknameDuplication: response.canCheckNicknameDuplication,
+                                                       canEditProfile: response.canEditProfile)
+
+        viewController?.displayChangedProfileState(with: viewModel)
     }
 
     func presentNicknameDuplication(with response: EditProfileModels.CheckNicknameDuplication.Response) {
-        let viewModel = Models.CheckNicknameDuplication.ViewModel(isValidNickname: response.isValid)
-        viewController?.displayNicknameDuplication(viewModel: viewModel)
+        return
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
@@ -37,7 +37,8 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
     }
 
     func presentProfileState(with response: Models.ChangeProfile.Response) {
-        let viewModel = Models.ChangeProfile.ViewModel(nicknameAlertDescription: response.nicknameAlertDescription,
+        let viewModel = Models.ChangeProfile.ViewModel(nicknameState: response.nicknameState, 
+                                                       nicknameAlertDescription: response.nicknameAlertDescription,
                                                        introduceAlertDescription: response.introduceAlertDescription,
                                                        canCheckNicknameDuplication: response.canCheckNicknameDuplication,
                                                        canEditProfile: response.canEditProfile)

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfilePresenter.swift
@@ -10,8 +10,8 @@ import UIKit
 
 protocol EditProfilePresentationLogic {
     func presentProfile(with response: EditProfileModels.FetchProfile.Response)
+    func presentProfile(with response: EditProfileModels.EditProfile.Response)
     func presentProfileState(with response: EditProfileModels.ChangeProfile.Response)
-
     func presentNicknameDuplication(with response: EditProfileModels.CheckNicknameDuplication.Response)
 }
 
@@ -31,9 +31,13 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
         viewController?.displayProfile(with: viewModel)
     }
 
+    func presentProfile(with response: EditProfileModels.EditProfile.Response) {
+        viewController?.displayProfileEditCompleted(with: Models.EditProfile.ViewModel())
+    }
+
     func presentProfileState(with response: Models.ChangeProfile.Response) {
-        let viewModel = Models.ChangeProfile.ViewModel(nicknameAlertDescription: response.newNicknameState.description,
-                                                       introduceAlertDescription: response.newIntroduceState.description,
+        let viewModel = Models.ChangeProfile.ViewModel(nicknameAlertDescription: response.nicknameAlertDescription,
+                                                       introduceAlertDescription: response.introduceAlertDescription,
                                                        canCheckNicknameDuplication: response.canCheckNicknameDuplication,
                                                        canEditProfile: response.canEditProfile)
 
@@ -41,7 +45,9 @@ final class EditProfilePresenter: EditProfilePresentationLogic {
     }
 
     func presentNicknameDuplication(with response: EditProfileModels.CheckNicknameDuplication.Response) {
-        return
+        let viewModel = Models.CheckNicknameDuplication.ViewModel(isValidNickname: response.isValid,
+                                                                  canEditProfile: response.canEditProfile)
+        viewController?.displayNicknameDuplication(with: viewModel)
     }
 
 }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileRouter.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileRouter.swift
@@ -16,7 +16,7 @@ protocol EditProfileDataPassing {
     var dataStore: EditProfileDataStore? { get }
 }
 
-final class EditProfileRouter: NSObject, EditProfileRoutingLogic, EditProfileDataPassing {
+final class EditProfileRouter: EditProfileRoutingLogic, EditProfileDataPassing {
 
     // MARK: - Properties
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -273,8 +273,9 @@ extension EditProfileViewController: EditProfileDisplayLogic {
         nicknameAlertLabel.isHidden = viewModel.nicknameAlertDescription == nil
         introduceAlertLabel.text = viewModel.introduceAlertDescription
         introduceAlertLabel.isHidden = viewModel.introduceAlertDescription == nil
-
-        checkDuplicateNicknameButton.isEnabled = viewModel.canCheckNicknameDuplication == true ? true : checkDuplicateNicknameButton.isEnabled
+        if let canCheckNicknameDuplication = viewModel.canCheckNicknameDuplication {
+            checkDuplicateNicknameButton.isEnabled = canCheckNicknameDuplication
+        }
         confirmButton.isEnabled = viewModel.canEditProfile
     }
 
@@ -285,8 +286,4 @@ extension EditProfileViewController: EditProfileDisplayLogic {
         confirmButton.isEnabled = viewModel.canEditProfile
         isValidNickname = viewModel.isValidNickname
     }
-}
-
-#Preview {
-    EditProfileViewController()
 }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -266,6 +266,7 @@ extension EditProfileViewController: EditProfileDisplayLogic {
 
     func displayProfileEditCompleted(with viewModel: EditProfileModels.EditProfile.ViewModel) {
         Toast.shared.showToast(message: "프로필 변경이 반영되었습니다.")
+        confirmButton.isEnabled = false
     }
 
     func displayChangedProfileState(with viewModel: EditProfileModels.ChangeProfile.ViewModel) {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -290,6 +290,7 @@ extension EditProfileViewController: EditProfileDisplayLogic {
     func displayChangedProfileState(with viewModel: EditProfileModels.ChangeProfile.ViewModel) {
         nicknameAlertLabel.text = viewModel.nicknameAlertDescription
         nicknameAlertLabel.isHidden = viewModel.nicknameAlertDescription == nil
+        nicknameAlertLabel.textColor = viewModel.nicknameState == .valid ? .correct : .error
         introduceAlertLabel.text = viewModel.introduceAlertDescription
         introduceAlertLabel.isHidden = viewModel.introduceAlertDescription == nil
         if let canCheckNicknameDuplication = viewModel.canCheckNicknameDuplication {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -274,7 +274,7 @@ extension EditProfileViewController: EditProfileDisplayLogic {
         introduceAlertLabel.text = viewModel.introduceAlertDescription
         introduceAlertLabel.isHidden = viewModel.introduceAlertDescription == nil
 
-        checkDuplicateNicknameButton.isEnabled = viewModel.canCheckNicknameDuplication == true
+        checkDuplicateNicknameButton.isEnabled = viewModel.canCheckNicknameDuplication == true ? true : checkDuplicateNicknameButton.isEnabled
         confirmButton.isEnabled = viewModel.canEditProfile
     }
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -12,7 +12,7 @@ import PhotosUI
 import OSLog
 
 protocol EditProfileDisplayLogic: AnyObject {
-    func displayProfile(with viewModel: EditProfileModels.FetchProfile.ViewModel)
+    func displayProfile(with viewModel: EditProfileModels.SetProfile.ViewModel)
     func displayProfileEditCompleted(with viewModel: EditProfileModels.EditProfile.ViewModel)
     func displayChangedProfileState(with viewModel: EditProfileModels.ChangeProfile.ViewModel)
     func displayNicknameDuplication(with viewModel: EditProfileModels.CheckNicknameDuplication.ViewModel)
@@ -141,7 +141,7 @@ final class EditProfileViewController: BaseViewController {
     override func setUI() {
         super.setUI()
         title = "프로필 수정"
-        interactor?.fetchProfile(with: Models.FetchProfile.Request())
+        interactor?.setProfile(with: Models.SetProfile.Request())
     }
 
     override func setConstraints() {
@@ -269,7 +269,7 @@ extension EditProfileViewController: PHPickerViewControllerDelegate {
 // MARK: - Display Logic
 
 extension EditProfileViewController: EditProfileDisplayLogic {
-    func displayProfile(with viewModel: Models.FetchProfile.ViewModel) {
+    func displayProfile(with viewModel: Models.SetProfile.ViewModel) {
         nicknameTextfield.text = viewModel.nickname
         if let introduce = viewModel.introduce {
             introduceTextfield.text = introduce

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -93,7 +93,7 @@ final class EditProfileViewController: BaseViewController {
     private lazy var editProfileImageController: UIAlertController = {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let defaultAction = UIAlertAction(title: "기본 이미지로 변경", style: .default) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.changedProfileImageData = nil
             self.changedProfileImageExtension = nil
             self.profileImageView.image = UIImage.profile
@@ -235,13 +235,12 @@ extension EditProfileViewController: PHPickerViewControllerDelegate {
         picker.dismiss(animated: true) {
             let item = results.first?.itemProvider
             if let item = item, item.canLoadObject(ofClass: UIImage.self) {
-                item.loadFileRepresentation(for: .image) { url, Bool, error in
+                item.loadFileRepresentation(for: .image) { url, _, error in
                     if let error {
                         os_log(.error, log: .ui, "%@", error.localizedDescription)
                     }
 
                     if let url { // item.loadFileRepresentation에서 주는 url은 클로저가 끝나면 없어지는 temporary file url이므로, 복사해서 사용한다.
-                        let fileData = FileManager.default.contents(atPath: url.path())
                         let pathExtension = url.pathExtension
                         let temporaryCopyFileName = UUID().uuidString + ".\(pathExtension)"
                         let temporaryCopyFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(temporaryCopyFileName)

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -213,7 +213,7 @@ final class EditProfileViewController: BaseViewController {
     }
 
     @objc private func editProfileImageButtonDidTap() {
-        self.present(phPickerViewController, animated: true)
+        self.present(editProfileImageController, animated: true)
     }
 
     @objc private func confirmButtonDidTap() {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -265,7 +265,7 @@ extension EditProfileViewController: EditProfileDisplayLogic {
     }
 
     func displayProfileEditCompleted(with viewModel: EditProfileModels.EditProfile.ViewModel) {
-        Toast.shared.showToast(message: "프로필 변경이 반영되었습니다.")
+        Toast.shared.showToast(message: viewModel.toastMessage)
         confirmButton.isEnabled = false
     }
 

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -86,6 +86,7 @@ final class EditProfileViewController: BaseViewController {
         let button = LOButton(style: .basic)
         button.isEnabled = false
         button.setTitle("완료", for: .normal)
+        button.addTarget(self, action: #selector(confirmButtonDidTap), for: .touchUpInside)
         return button
     }()
 
@@ -215,7 +216,7 @@ final class EditProfileViewController: BaseViewController {
         self.present(phPickerViewController, animated: true)
     }
 
-    @objc private func completeButtonDidTap() {
+    @objc private func confirmButtonDidTap() {
         guard let nickname = nicknameTextfield.text,
               let introduce = introduceTextfield.text
         else { return }

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
@@ -54,7 +54,9 @@ final class ProfileInteractor: ProfileBusinessLogic, ProfileDataStore {
 
     @discardableResult
     func fetchProfile(with request: ProfileModels.FetchProfile.Request) -> Task<Bool, Never> {
-        Task {
+        fetchPostsPage = 1
+        canFetchMorePosts = true
+        return Task {
             guard let userProfile = await userWorker?.fetchProfile(by: profileId) else {
                 return false
             }

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileRouter.swift
@@ -40,7 +40,7 @@ final class ProfileRouter: ProfileRoutingLogic, ProfileDataPassing {
     }
 
     func routeToSetting() {
-        let settingViewController: SettingViewController = SettingViewController()
+        let settingViewController = SettingViewController()
         viewController?.navigationController?.pushViewController(settingViewController, animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -72,6 +72,10 @@ final class ProfileViewController: BaseViewController {
         super.viewDidLoad()
         setNavigationBar()
         setDataSource()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         fetchProfile()
     }
 

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpPresenter.swift
@@ -25,7 +25,7 @@ final class SignUpPresenter: SignUpPresentationLogic {
 
     func presentNicknameValidation(with response: Models.ValidateNickname.Response) {
         let viewModel = Models.ValidateNickname.ViewModel(canCheckDuplication: response.nicknameState == .valid,
-                                                          alertDescription: response.nicknameState.alertDescription)
+                                                          alertDescription: response.nicknameState.description)
         viewController?.displayNicknameValidation(response: viewModel)
     }
 

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -194,6 +194,10 @@ final class MockUserWorker: UserWorkerProtocol {
         }
     }
 
+    func setProfileImageDefault() async -> Bool {
+        true
+    }
+
     func modifyProfileImage(data: Data, to url: String) async -> Bool {
         true
     }

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -194,12 +194,11 @@ final class MockUserWorker: UserWorkerProtocol {
         }
     }
 
-    func modifyProfileImage(from fileURL: URL, to url: String) async -> Bool {
-        return true
+    func modifyProfileImage(data: Data, to url: String) async -> Bool {
+        true
     }
 
     func fetchImagePresignedURL(with fileType: String) async -> String? {
         return nil
     }
-
 }

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -10,7 +10,6 @@ import Foundation
 import OSLog
 
 final class MockUserWorker: UserWorkerProtocol {
-    
 
     // MARK: - Properties
 
@@ -193,6 +192,14 @@ final class MockUserWorker: UserWorkerProtocol {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil
         }
+    }
+
+    func modifyProfileImage(from fileURL: URL, to url: String) async -> Bool {
+        return true
+    }
+
+    func fetchImagePresignedURL(with fileType: String) async -> String? {
+        return nil
     }
 
 }

--- a/iOS/Layover/Layover/Workers/UserWorker.swift
+++ b/iOS/Layover/Layover/Workers/UserWorker.swift
@@ -98,7 +98,7 @@ final class UserWorker: UserWorkerProtocol {
 
     func modifyProfileImage(data: Data, to url: String) async -> Bool {
         do {
-            let responseData = try await provider.upload(data: data, to: url, method: .PUT)
+            let responseData = try await provider.upload(data: data, to: url)
             return true
         } catch {
             os_log(.error, log: .default, "Failed to modify profile image with error: %@", error.localizedDescription)

--- a/iOS/Layover/Layover/Workers/UserWorker.swift
+++ b/iOS/Layover/Layover/Workers/UserWorker.swift
@@ -178,7 +178,7 @@ final class UserWorker: UserWorkerProtocol {
         let endPoint = userEndPointFactory.makeUserProfileImageDefaultEndPoint()
 
         do {
-            let response = try await provider.request(with: endPoint)
+            let _ = try await provider.request(with: endPoint)
             return true
         } catch {
             os_log(.error, log: .data, "Error: %s", error.localizedDescription)

--- a/iOS/Layover/Layover/Workers/UserWorker.swift
+++ b/iOS/Layover/Layover/Workers/UserWorker.swift
@@ -38,6 +38,7 @@ protocol UserWorkerProtocol {
     func fetchProfile(by id: Int?) async -> Member?
     func fetchPosts(at page: Int, of id: Int?) async -> [Post]?
     func fetchImageData(with url: URL) async -> Data?
+    func setProfileImageDefault() async -> Bool
     func fetchImagePresignedURL(with fileType: String) async -> String?
 }
 
@@ -139,7 +140,7 @@ final class UserWorker: UserWorkerProtocol {
     func logout() {
         authManager.logout()
     }
-    
+
     func fetchProfile(by id: Int?) async -> Member? {
         let endPoint = userEndPointFactory.makeUserInformationEndPoint(with: id)
 
@@ -170,6 +171,18 @@ final class UserWorker: UserWorkerProtocol {
         } catch {
             os_log(.error, log: .data, "Error: %s", error.localizedDescription)
             return nil
+        }
+    }
+
+    func setProfileImageDefault() async -> Bool {
+        let endPoint = userEndPointFactory.makeUserProfileImageDefaultEndPoint()
+
+        do {
+            let response = try await provider.request(with: endPoint)
+            return true
+        } catch {
+            os_log(.error, log: .data, "Error: %s", error.localizedDescription)
+            return false
         }
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 프로필 변경 화면 VIP 구현
- 프로필 화면 갱신 viewWIllAppear에서 하도록 변경

#### 📌 변경 사항
> [!NOTE] 
> PHPickerController로 프로필 이미지 데이터 접근 처리

- PHPickerResult의 itemProvider로 파일의 url에 접근할 수 있는 `loadFileRepresentation` 메서드는 인자로 넘겨주는 url이 해당 클로저 내에서만 유효한 임시적인 파일 url입니다.
- 하지만 해당 파일 데이터를 서버에 넘겨주고 처리해야 하는 메서드는 비동기 메서드 이기 때문에 해당 클로저가 종료될 시점내에 실행이 완료된다는 보장이 없습니다.
- 따라서 tmp 디렉토리 내에서 임시 url의 copyItem을 수행해서 파일을 복사하여, 실제 파일 데이터가 비동기 메서드 실행 시점에서도 유효하도록 하여 처리할 수 있었습니다.
- tmp 디렉토리는 지난번에 알려주신 대로 앱 종료시 디렉토리가 비워지지만, 데이터가 쌓일 것을 대비해 처리가 끝나면 명시적으로 지워지도록 처리했습니다.

그 외, 프로필 변경 이후 프로필 화면으로 다시 복귀할 때 변경한 데이터로 적용시켜주기 위해, 
viewWillAppear로 프로필 데이터를 가져오는 시점을 변경했습니다.

##### 📸 ScreenShot
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-09 at 01 56 17](https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/1f278b22-786f-4415-9273-0f14ea753178)

#### Linked Issue
close #236 
