### PR TITLE
bug: 실행 시 네비게이션 바 중첩 버그 수정

### DIFF
--- a/iOS/Layover/Layover/SceneDelegate.swift
+++ b/iOS/Layover/Layover/SceneDelegate.swift
@@ -20,7 +20,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let window = UIWindow(windowScene: windowScene)
         let rootViewController = AuthManager.shared.isLoggedIn ? MainTabBarViewController() : LoginViewController()
-        window.rootViewController = UINavigationController(rootViewController: rootViewController)
+        let rootNavigationController = UINavigationController(rootViewController: rootViewController)
+
+        if rootViewController is MainTabBarViewController {
+            rootNavigationController.setNavigationBarHidden(true, animated: false)
+        }
+
+        window.rootViewController = rootNavigationController
         self.window = window
         addNotificationObservers()
         window.makeKeyAndVisible()

--- a/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginRouter.swift
@@ -28,6 +28,7 @@ final class LoginRouter: LoginRoutingLogic, LoginDataPassing {
 
     func routeToMainTabBar() {
         let tabBarViewController = MainTabBarViewController()
+        viewController?.navigationController?.setNavigationBarHidden(true, animated: true)
         viewController?.navigationController?.setViewControllers([tabBarViewController], animated: true)
     }
 

--- a/iOS/Layover/Layover/Scenes/Setting/SettingRouter.swift
+++ b/iOS/Layover/Layover/Scenes/Setting/SettingRouter.swift
@@ -40,6 +40,7 @@ final class SettingRouter: SettingRoutingLogic, SettingDataPassing {
         let loginViewController = LoginViewController()
         guard let rootNavigationController = viewController?.view.window?.rootViewController
                 as? UINavigationController else { return }
+        rootNavigationController.setNavigationBarHidden(false, animated: true)
         rootNavigationController.setViewControllers([loginViewController], animated: true)
     }
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
네비게이션 바 중첩 버그를 수정했습니다.

#### 📌 변경 사항
- 해당 버그를 픽스하면서 안 사실인데, 원래는 tabBarController 자체가 navigationController에 embedded 되는 것 자체가 어색한 일이라고 합니다.
- 그래서 애플에서도 UITabbarController의 navigationController 프로퍼티는 항상 nil을 반환시키도록 했다고 합니다.
- 제가 UINavigationController 안에 UITabbarController를 포함시키게 된 건, 로그인 화면과 회원가입이 끝나면 메인 탭바를 오른쪽에서 푸시시키는 애니메이션을 주고자 했는데, 다른 방법을 고려하던가 하는게 좋을 것 같습니다.
  - 물론 그래서 window의 rootViewController를 런타임에 할당으로 바꾸게 되면, 깜빡거리면서 UI적으로 어색한 형태가 나옵니다...
  - 애니메이션을 주는 방법도 있는데 이 방법을 고려하던, 다른 방법을 고려하던 장기적으로는 대체할 방법을 찾아야 할 것 같습니다.
  - 애니메이션은 적용하는게 좀 복잡해 보였어요
- 지금 고친 방법은 우선 메인에 진입 할때는 탭바 숨김을, 로그인으로 진입할때는 탭바를 보이도록 고친 것입니다.

#### Linked Issue
close #260 
