### PR TITLE
feat: 기본 이미지 설정 api 구현 + 응답 형식 변경에 따른 스웨거 변경

### DIFF
--- a/BE/layover/src/member/dtos/member-infos-res.dto.ts
+++ b/BE/layover/src/member/dtos/member-infos-res.dto.ts
@@ -23,9 +23,9 @@ export class MemberInfosResDto {
     example: 'https://layover-profile-image.kr.obj...',
     description: '요청한 회원의 프로필 이미지를 다운받을 수 있는 url',
   })
-  profile_image_url: string;
+  profile_image_url: string | null;
 
-  constructor(id: number, username: string, introduce: string, profile_image_url: string) {
+  constructor(id: number, username: string, introduce: string, profile_image_url: string | null) {
     this.id = id;
     this.username = username;
     this.introduce = introduce;

--- a/BE/layover/src/member/member.controller.ts
+++ b/BE/layover/src/member/member.controller.ts
@@ -114,7 +114,9 @@ export class MemberController {
     const profileImageKey = member.profile_image_key;
 
     const bucketname = process.env.NCLOUD_S3_PROFILE_BUCKET_NAME;
-    const preSignedUrl = generateDownloadPreSignedUrl(bucketname, profileImageKey);
+    let preSignedUrl: string;
+    if (profileImageKey !== 'default') preSignedUrl = generateDownloadPreSignedUrl(bucketname, profileImageKey);
+    else preSignedUrl = null;
 
     // 응답
     throw new CustomResponse(ECustomCode.SUCCESS, new MemberInfosResDto(id, username, introduce, preSignedUrl));
@@ -168,5 +170,21 @@ export class MemberController {
 
     // 응답
     throw new CustomResponse(ECustomCode.SUCCESS, new PreSignedUrlResDto(preSignedUrl));
+  }
+
+  @ApiOperation({
+    summary: '프로필 이미지를 기본 이미지로 변경',
+    description: '프로필 이미지를 기본 이미지로 변경합니다.',
+  })
+  @ApiResponse(MEMBER_SWAGGER.UPDATE_PROFILE_IMAGE_TO_DEFAULT_SUCCESS)
+  @ApiResponse(SWAGGER.ACCESS_TOKEN_TIMEOUT_RESPONSE)
+  @ApiBearerAuth('token')
+  @Post('profile-image/default')
+  async updateProfileImageToDefault(@CustomHeader(new JwtValidationPipe()) payload: tokenPayload) {
+    // db에 반영
+    await this.memberService.updateProfileImage(payload.memberId, 'default');
+
+    // 응답
+    throw new CustomResponse(ECustomCode.SUCCESS);
   }
 }

--- a/BE/layover/src/member/member.swagger.ts
+++ b/BE/layover/src/member/member.swagger.ts
@@ -14,8 +14,7 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(CheckUsernameResDto) },
       },
@@ -28,8 +27,7 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(UsernameResDto) },
       },
@@ -42,8 +40,7 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(IntroduceResDto) },
       },
@@ -56,8 +53,7 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(DeleteMemberResDto) },
       },
@@ -70,10 +66,21 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(PreSignedUrlResDto) },
+      },
+    },
+  },
+
+  UPDATE_PROFILE_IMAGE_TO_DEFAULT_SUCCESS: {
+    status: HttpStatus.OK,
+    description: '프로필 이미지가 기본 이미지로 변경',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
+        statusCode: { type: 'number', example: HttpStatus.OK },
       },
     },
   },
@@ -84,8 +91,7 @@ export const MEMBER_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'boolean', example: '성공' },
+        message: { type: 'boolean', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(MemberInfosResDto) },
       },

--- a/BE/layover/src/oauth/oauth.swagger.ts
+++ b/BE/layover/src/oauth/oauth.swagger.ts
@@ -10,8 +10,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(TokenResDto) },
       },
@@ -23,8 +22,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(TokenResDto) },
       },
@@ -36,8 +34,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(TokenResDto) },
       },
@@ -49,8 +46,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(TokenResDto) },
       },
@@ -62,8 +58,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(TokenResDto) },
       },
@@ -75,8 +70,7 @@ export const OAUTH_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(CheckSignupResDto) },
       },

--- a/BE/layover/src/report/report.swagger.ts
+++ b/BE/layover/src/report/report.swagger.ts
@@ -9,8 +9,7 @@ export const REPORT_SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'SUCCESS' },
-        message: { type: 'string', example: '성공' },
+        message: { type: 'string', example: '요청이 성공적으로 처리되었습니다.' },
         statusCode: { type: 'number', example: HttpStatus.OK },
         data: { $ref: getSchemaPath(ReportResDto) },
       },

--- a/BE/layover/src/utils/swaggerUtils.ts
+++ b/BE/layover/src/utils/swaggerUtils.ts
@@ -7,7 +7,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: '<type><num>' },
         message: { type: 'string', example: '서버에서 처리한 예외' },
         statusCode: { type: 'number', example: '000' },
       },
@@ -20,7 +19,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'NEST_OFFER_EXCEPTION' },
         message: { type: 'string', example: 'message from nest' },
         statusCode: { type: 'number', example: '000' },
       },
@@ -33,7 +31,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'INTERNAL_SERVER_ERROR' },
         message: { type: 'string', example: 'message from nest' },
         statusCode: { type: 'number', example: HttpStatus.INTERNAL_SERVER_ERROR },
       },
@@ -46,7 +43,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'OAUTH01' },
         message: { type: 'string', example: '회원가입이 되지 않은 유저입니다.' },
         statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
       },
@@ -59,7 +55,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'JWT02' },
         message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
         statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
       },
@@ -72,7 +67,6 @@ export const SWAGGER = {
     schema: {
       type: 'object',
       properties: {
-        customCode: { type: 'string', example: 'JWT02' },
         message: { type: 'string', example: '토큰 만료기간이 경과하였습니다.' },
         statusCode: { type: 'number', example: HttpStatus.UNAUTHORIZED },
       },


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 프로필 이미지 기본 이미지로 설정하는 api 새로 구현
- 이제 응답에 customCode가 사라져서 Member/Oauth/report 쪽 스웨거에 해당 사항 반영

#### 📌 변경 사항
- 없습니다.

##### 📸 ScreenShot
<img width="368" alt="스크린샷 2023-12-09 오후 3 18 47" src="https://github.com/boostcampwm2023/iOS09-Layover/assets/111403658/e5f4f040-f3e2-4c3b-b32d-38160d001a9e">


#### Linked Issue
close #263 
