### PR TITLE
test: 홈 테스트 코드 수정

### DIFF
--- a/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomePresenter.swift
@@ -10,7 +10,6 @@ import UIKit
 
 protocol HomePresentationLogic {
     func presentPosts(with response: HomeModels.FetchPosts.Response)
-    func presentThumbnailImage(with response: HomeModels.FetchThumbnailImageData.Response)
     func presentPlaybackScene(with response: HomeModels.PlayPosts.Response)
     func presentTagPlayList(with response: HomeModels.ShowTagPlayList.Response)
 }
@@ -40,12 +39,6 @@ final class HomePresenter: HomePresentationLogic {
 
         let viewModel = Models.FetchPosts.ViewModel(displayedPosts: displayedPosts)
         viewController?.displayPosts(with: viewModel)
-    }
-
-    func presentThumbnailImage(with response: Models.FetchThumbnailImageData.Response) {
-        let viewModel = Models.FetchThumbnailImageData.ViewModel(imageData: response.imageData,
-                                                                 indexPath: response.indexPath)
-        viewController?.displayThumbnailImage(with: viewModel)
     }
 
     // MARK: - UseCase Present PlaybackScene

--- a/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Home/HomeViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 
 protocol HomeDisplayLogic: AnyObject {
     func displayPosts(with viewModel: HomeModels.FetchPosts.ViewModel)
-    func displayThumbnailImage(with viewModel: HomeModels.FetchThumbnailImageData.ViewModel)
     func routeToPlayback()
     func routeToTagPlayList()
 }
@@ -236,14 +235,6 @@ extension HomeViewController: HomeDisplayLogic {
         carouselDatasource.apply(snapshot) {
             self.playVideoAtCenterCell()
         }
-    }
-
-    func displayThumbnailImage(with viewModel: HomeModels.FetchThumbnailImageData.ViewModel) {
-        guard let cell = carouselCollectionView.cellForItem(at: viewModel.indexPath) as? HomeCarouselCollectionViewCell,
-              let thumbnailImage = UIImage(data: viewModel.imageData)
-        else { return }
-
-        cell.configure(thumbnailImage: thumbnailImage)
     }
 
     func routeToPlayback() {

--- a/iOS/Layover/LayoverTests/Scenes/Home/HomeInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Home/HomeInteractorTests.swift
@@ -38,8 +38,6 @@ final class HomeInteractorTests: XCTestCase {
     final class HomePresentationLogicSpy: HomePresentationLogic { // 호출 테스트를 위한 Spy
         var presentPostsCalled = false
         var presentPostsReceivedResponse: Models.FetchPosts.Response!
-        var presentThumbnailImageCalled = false
-        var presentThumbnailImageReceivedResponse: Models.FetchThumbnailImageData.Response!
         var presentPlaybackSceneCalled = false
         var presentTagPlayListCalled = false
 
@@ -47,16 +45,11 @@ final class HomeInteractorTests: XCTestCase {
             presentPostsCalled = true
             presentPostsReceivedResponse = response
         }
-        
-        func presentThumbnailImage(with response: Models.FetchThumbnailImageData.Response) {
-            presentThumbnailImageCalled = true
-            presentThumbnailImageReceivedResponse = response
-        }
-        
+
         func presentPlaybackScene(with response: Models.PlayPosts.Response) {
             presentPlaybackSceneCalled = true
         }
-        
+
         func presentTagPlayList(with response: Models.ShowTagPlayList.Response) {
             presentTagPlayListCalled = true
         }
@@ -90,44 +83,21 @@ final class HomeInteractorTests: XCTestCase {
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts.count, 4, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
     }
 
-//    func test_fetchThumbnailImageData는_presenter의_presentThumbnailImage를_호출한다() async throws {
-//        // Arrange
-//        let spy = HomePresentationLogicSpy()
-//        sut.presenter = spy
-//
-//        guard let imageURL = URL(string: "https://cdnimg.melon.co.kr/resource/image/cds/musicstory/imgUrl20210831030133473.jpg/melon/quality/90/optimize") else {
-//            XCTFail("URL 생성 실패")
-//            return
-//        }
-//
-//        let request = Models.FetchThumbnailImageData.Request(imageURL: imageURL, indexPath: IndexPath())
-//
-//        // Act
-//        _ = await sut.fetchThumbnailImageData(with: request).value
-//
-//        // Assert
-//        XCTAssertTrue(spy.presentThumbnailImageCalled, "fetchThumbnailImageData()가 presenter의 presentThumbnailImage()를 호출했다.")
-//    }
-//
-//    func test_fetchThumbnailImageData는_presenter에게_올바른_데이터를_전달한다() async throws {
-//        // Arrange
-//        let spy = HomePresentationLogicSpy()
-//        sut.presenter = spy
-//
-//        guard let imageURL = URL(string: "https://cdnimg.melon.co.kr/resource/image/cds/musicstory/imgUrl20210831030133473.jpg/melon/quality/90/optimize") else {
-//            XCTFail("URL 생성 실패")
-//            return
-//        }
-//
-//        let request = Models.FetchThumbnailImageData.Request(imageURL: imageURL, indexPath: IndexPath())
-//
-//        // Act
-//        _ = await sut.fetchThumbnailImageData(with: request).value
-//
-//        // Assert
-//        let assertImageData = try Data(contentsOf: Bundle(for: type(of: self)).url(forResource: "sample", withExtension: "jpeg")!)
-//        XCTAssertEqual(spy.presentThumbnailImageReceivedResponse.imageData, assertImageData,"fetchThumbnailImageData()가 presenter에게 올바른 데이터를 저장했다.")
-//    }
+    func test_fetchPost는_presenter에게_올바른_이미지_데이터를_전달한다() async throws {
+        // Arrange
+        let spy = HomePresentationLogicSpy()
+        sut.presenter = spy
+        let request = Models.FetchPosts.Request()
+        let imageData = try Data(contentsOf: Bundle(for: type(of: self)).url(forResource: "sample", withExtension: "jpeg")!)
+
+        // Act
+        _ = await sut.fetchPosts(with: request).value
+
+        // Assert
+        spy.presentPostsReceivedResponse.posts.forEach {
+            XCTAssertEqual($0.thumbnailImageData, imageData, "fetchPost()가 presenter에게 올바른 이미지 데이터를 전달했다.")
+        }
+    }
 
     func test_playPosts는_자신의_selectedIndex값을_변경한다() async throws {
         // Arrange

--- a/iOS/Layover/LayoverTests/Scenes/Home/HomePresenterTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Home/HomePresenterTests.swift
@@ -51,11 +51,6 @@ final class HomePresenterTests: XCTestCase {
             displayPostsReceivedViewModel = viewModel
         }
         
-        func displayThumbnailImage(with viewModel: Layover.HomeModels.FetchThumbnailImageData.ViewModel) {
-            displayThumbnailImageCalled = true
-            displayThumbnailImageReceivedViewModel = viewModel
-        }
-        
         func routeToPlayback() {
             routeToPlaybackCalled = true
         }

--- a/iOS/Layover/LayoverTests/Scenes/Home/HomePresenterTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Home/HomePresenterTests.swift
@@ -172,20 +172,6 @@ final class HomePresenterTests: XCTestCase {
         XCTAssertEqual(spy.displayPostsReceivedViewModel.displayedPosts.count, 0, "비디오 URL이 nil인 데이터는 뷰에게 전달하지 않는다.")
     }
 
-    func test_presentThumbnailImage는_데이터를_받아오면_뷰의_displayThumbnailImage를_실행한다() {
-        // arrange
-        let spy = HomeDisplayLogicSpy()
-        sut.viewController = spy
-
-        let response = Models.FetchThumbnailImageData.Response(imageData: Data(), indexPath: IndexPath())
-
-        // act
-        sut.presentThumbnailImage(with: response)
-
-        // assert
-        XCTAssertTrue(spy.displayThumbnailImageCalled, "presentThumbnailImage는 displayThumbnailImage를 실행해서 뷰에게 데이터를 전달했다.")
-    }
-
     func test_presentPlaybackScene은_뷰의_routeToPlayback을_실행한다() {
         // arrange
         let spy = HomeDisplayLogicSpy()


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 이미지 로드 방식이 변경됨에 따라 불필요한 썸네일 로드 메서드들을 삭제했습니다.
- 대신 게시글을 전달할 때 썸네일 이미지 데이터(샘플 이미지)까지 전달하는지 확인하는 테스트 메서드를 추가로 구현했고, MockHomeWorker를 수정했습니다.
<img width="1362" alt="image" src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/82c2e2dd-6bb6-4a97-b190-472850f4644a">

#### Linked Issue
close #278 
