### PR TITLE
chore: 프로필 이미지 변경 요청 시 MimeType 추출방식 변경, 로딩 인디케이터 구현

### DIFF
--- a/iOS/Layover/Layover/Network/Provider/Provider.swift
+++ b/iOS/Layover/Layover/Network/Provider/Provider.swift
@@ -14,7 +14,7 @@ protocol ProviderType {
     func request<R: Decodable, E: RequestResponsable>(with endPoint: E, authenticationIfNeeded: Bool, retryCount: Int) async throws -> R where E.Response == R
     func request(url: URL) async throws -> Data
     func request(url: String) async throws -> Data
-    func upload(data: Data, to presignedURL: String, method: HTTPMethod) async throws -> Data
+    func upload(data: Data, contentType: String, to presignedURL: String, method: HTTPMethod) async throws -> Data
     func upload(fromFile: URL,
                 to url: String,
                 method: HTTPMethod,
@@ -31,8 +31,9 @@ extension ProviderType {
                                  retryCount: retryCount)
     }
 
-    func upload(data: Data, to presignedURL: String, method: HTTPMethod = .PUT) async throws -> Data {
+    func upload(data: Data, contentType: String, to presignedURL: String, method: HTTPMethod = .PUT) async throws -> Data {
         return try await upload(data: data,
+                                contentType: contentType,
                                 to: presignedURL,
                                 method: method)
     }
@@ -132,9 +133,8 @@ class Provider: ProviderType {
     }
 
     // 이미지 업로드용
-    func upload(data: Data, to presignedURL: String, method: HTTPMethod = .PUT) async throws -> Data {
-        guard let contentType = URLComponents(string: presignedURL)?.queryItems?.first(where: { $0.name == "Content-Type"} )?.value,
-              let url = URL(string: presignedURL) else { throw NetworkError.components }
+    func upload(data: Data, contentType: String, to presignedURL: String, method: HTTPMethod = .PUT) async throws -> Data {
+        guard let url = URL(string: presignedURL) else { throw NetworkError.components }
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = method.rawValue
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")

--- a/iOS/Layover/Layover/Scenes/BaseViewController.swift
+++ b/iOS/Layover/Layover/Scenes/BaseViewController.swift
@@ -36,4 +36,23 @@ class BaseViewController: UIViewController {
         navigationItem.backBarButtonItem = UIBarButtonItem(
                 title: "", style: .plain, target: nil, action: nil)
     }
+
+    func showLoading() {
+        let loadingIndicatorView: UIActivityIndicatorView
+        if let existedView = view.window?.subviews.first(where: { $0 is UIActivityIndicatorView } ) as? UIActivityIndicatorView {
+            loadingIndicatorView = existedView
+        } else {
+            loadingIndicatorView = UIActivityIndicatorView(style: .large)
+            loadingIndicatorView.color = UIColor.primaryPurple
+            /// 다른 UI가 눌리지 않도록 indicatorView의 크기를 full로 할당
+            loadingIndicatorView.frame = view.window?.frame ?? view.bounds
+            view.window?.addSubview(loadingIndicatorView)
+        }
+        loadingIndicatorView.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
+        loadingIndicatorView.startAnimating()
+    }
+
+    func hideLoading() {
+        view.window?.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
+    }
 }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -226,6 +226,7 @@ final class EditProfileViewController: BaseViewController {
                                                  introduce: introduce,
                                                  profileImageData: changedProfileImageData,
                                                  profileImageExtension: changedProfileImageExtension)
+        showLoading()
         interactor?.editProfile(with: request)
     }
 }
@@ -284,7 +285,7 @@ extension EditProfileViewController: EditProfileDisplayLogic {
 
     func displayProfileEditCompleted(with viewModel: EditProfileModels.EditProfile.ViewModel) {
         Toast.shared.showToast(message: viewModel.toastMessage)
-        confirmButton.isEnabled = false
+        hideLoading()
     }
 
     func displayChangedProfileState(with viewModel: EditProfileModels.ChangeProfile.ViewModel) {

--- a/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockUserWorker.swift
@@ -198,7 +198,7 @@ final class MockUserWorker: UserWorkerProtocol {
         true
     }
 
-    func modifyProfileImage(data: Data, to url: String) async -> Bool {
+    func modifyProfileImage(data: Data, contentType: String, to url: String) async -> Bool {
         true
     }
 

--- a/iOS/Layover/Layover/Workers/UserWorker.swift
+++ b/iOS/Layover/Layover/Workers/UserWorker.swift
@@ -30,7 +30,7 @@ protocol UserWorkerProtocol {
     func validateNickname(_ nickname: String) -> NicknameState
     func modifyNickname(to nickname: String) async -> String?
     func checkNotDuplication(for userName: String) async -> Bool?
-    func modifyProfileImage(data: Data, to url: String) async -> Bool
+    func modifyProfileImage(data: Data, contentType: String, to url: String) async -> Bool
     func modifyIntroduce(to introduce: String) async -> String?
     func withdraw() async -> String?
     func logout()
@@ -97,9 +97,9 @@ final class UserWorker: UserWorkerProtocol {
         }
     }
 
-    func modifyProfileImage(data: Data, to url: String) async -> Bool {
+    func modifyProfileImage(data: Data, contentType: String, to url: String) async -> Bool {
         do {
-            let responseData = try await provider.upload(data: data, to: url)
+            let responseData = try await provider.upload(data: data, contentType: contentType, to: url)
             return true
         } catch {
             os_log(.error, log: .default, "Failed to modify profile image with error: %@", error.localizedDescription)


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- MimeType을 기존 PresignedURL 로부터 추출하는 것에서, UTType을 이용해 추출하도록 변경했습니다.
- 네트워킹 시 로딩중임을 보여주고, 유저의 추가적인 입력을 막기 위해 LoadingIndicator 구현했습니다.

#### 📌 변경 사항
> [!NOTE]
> 로딩 인디케이터 기능 구현

- BaseViewController에 LoadingIndicator 기능을 구현해놨습니다.
- 사용 방법도 간단합니다!
```swift
// ViewController 내에서
showLoading()
hideLoading()
```
- 참고로 로딩 인디케이터 뷰가 보이는 상황에서는 로딩 인디케이터 뷰가 최상단에 떠있도록 해놓았기 때문에 
로딩이 끝날 때까지 유저의 추가적인 입력을 신경쓰지 않아도 됩니다.

##### 📸 ScreenShot
작동, 구현화면
<img src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/de1e05a0-b77c-424d-822d-993e7a4e52bc" width=40%>

#### Linked Issue
close #280 
