### PR TITLE
chore: 탈퇴 시 안내 문구 수정, 회원가입시 memberId UserDefaults에 저장하도록 변경

### DIFF
--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -8,7 +8,7 @@
 protocol AuthManagerProtocol: AnyObject {
     var accessToken: String? { get set }
     var refreshToken: String? { get set }
-    var isLoggedIn: Bool { get set }
+    var isLoggedIn: Bool? { get set }
     var memberId: Int? { get set }
 
     func logout()
@@ -30,7 +30,7 @@ final class AuthManager: AuthManagerProtocol {
     @KeychainStored(key: "accessToken") var accessToken: String?
     @KeychainStored(key: "refreshToken") var refreshToken: String?
 
-    @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool
+    @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool?
     @UserDefaultStored(key: UserDefaultKey.memberId, defaultValue: nil) var memberId: Int?
 
     static let shared = AuthManager()

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -9,6 +9,7 @@ protocol AuthManagerProtocol: AnyObject {
     var accessToken: String? { get set }
     var refreshToken: String? { get set }
     var isLoggedIn: Bool { get set }
+    var memberId: Int? { get set }
 
     func logout()
 }
@@ -21,6 +22,7 @@ final class AuthManager: AuthManagerProtocol {
     @KeychainStored(key: "refreshToken") var refreshToken: String?
 
     @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool
+    @UserDefaultStored(key: UserDefaultKey.memberId, defaultValue: nil) var memberId: Int?
 
     static let shared = AuthManager()
 
@@ -29,6 +31,7 @@ final class AuthManager: AuthManagerProtocol {
     func logout() {
         accessToken = nil
         refreshToken = nil
+        memberId = nil
         isLoggedIn = false
     }
 }

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -13,6 +13,7 @@ protocol AuthManagerProtocol: AnyObject {
     var loginType: LoginType? { get set }
     var memberID: Int? { get set }
 
+    func login(accessToken: String?, refreshToken: String?, memberID: Int?, loginType: LoginType?)
     func logout()
 }
 
@@ -22,6 +23,14 @@ enum LoginType: String, Codable {
 }
 
 extension AuthManagerProtocol {
+    func login(accessToken: String?, refreshToken: String?, memberID: Int?, loginType: LoginType?) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.memberID = memberID
+        self.loginType = loginType
+        isLoggedIn = true
+    }
+
     func logout() {
         accessToken = nil
         refreshToken = nil

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -11,7 +11,7 @@ protocol AuthManagerProtocol: AnyObject {
     var refreshToken: String? { get set }
     var isLoggedIn: Bool? { get set }
     var loginType: LoginType? { get set }
-    var memberId: Int? { get set }
+    var memberID: Int? { get set }
 
     func logout()
 }
@@ -25,7 +25,7 @@ extension AuthManagerProtocol {
     func logout() {
         accessToken = nil
         refreshToken = nil
-        memberId = nil
+        memberID = nil
         loginType = nil
         isLoggedIn = false
     }
@@ -39,7 +39,7 @@ final class AuthManager: AuthManagerProtocol {
     @KeychainStored(key: "refreshToken") var refreshToken: String?
 
     @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool?
-    @UserDefaultStored(key: UserDefaultKey.memberId, defaultValue: nil) var memberId: Int?
+    @UserDefaultStored(key: UserDefaultKey.memberId, defaultValue: nil) var memberID: Int?
     @UserDefaultStored(key: UserDefaultKey.loginType, defaultValue: nil) var loginType: LoginType?
 
     static let shared = AuthManager()

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -5,13 +5,20 @@
 //  Created by 김인환 on 11/13/23.
 //
 
+
 protocol AuthManagerProtocol: AnyObject {
     var accessToken: String? { get set }
     var refreshToken: String? { get set }
     var isLoggedIn: Bool? { get set }
+    var loginType: LoginType? { get set }
     var memberId: Int? { get set }
 
     func logout()
+}
+
+enum LoginType: String, Codable {
+    case kakao
+    case apple
 }
 
 extension AuthManagerProtocol {
@@ -19,6 +26,7 @@ extension AuthManagerProtocol {
         accessToken = nil
         refreshToken = nil
         memberId = nil
+        loginType = nil
         isLoggedIn = false
     }
 }
@@ -32,6 +40,7 @@ final class AuthManager: AuthManagerProtocol {
 
     @UserDefaultStored(key: UserDefaultKey.isLoggedIn, defaultValue: false) var isLoggedIn: Bool?
     @UserDefaultStored(key: UserDefaultKey.memberId, defaultValue: nil) var memberId: Int?
+    @UserDefaultStored(key: UserDefaultKey.loginType, defaultValue: nil) var loginType: LoginType?
 
     static let shared = AuthManager()
 

--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -14,6 +14,15 @@ protocol AuthManagerProtocol: AnyObject {
     func logout()
 }
 
+extension AuthManagerProtocol {
+    func logout() {
+        accessToken = nil
+        refreshToken = nil
+        memberId = nil
+        isLoggedIn = false
+    }
+}
+
 final class AuthManager: AuthManagerProtocol {
 
     // MARK: Properties
@@ -27,11 +36,4 @@ final class AuthManager: AuthManagerProtocol {
     static let shared = AuthManager()
 
     private init() { }
-
-    func logout() {
-        accessToken = nil
-        refreshToken = nil
-        memberId = nil
-        isLoggedIn = false
-    }
 }

--- a/iOS/Layover/Layover/SceneDelegate.swift
+++ b/iOS/Layover/Layover/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        let rootViewController = AuthManager.shared.isLoggedIn ? MainTabBarViewController() : LoginViewController()
+        let rootViewController = AuthManager.shared.isLoggedIn == true ? MainTabBarViewController() : LoginViewController()
         let rootNavigationController = UINavigationController(rootViewController: rootViewController)
 
         if rootViewController is MainTabBarViewController {

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -92,7 +92,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.refreshToken = result.data?.refreshToken
             authManager.isLoggedIn = true
             authManager.loginType = .kakao
-            authManager.memberId = await fetchMemberId()
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
@@ -122,7 +122,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.refreshToken = result.data?.refreshToken
             authManager.isLoggedIn = true
             authManager.loginType = .apple
-            authManager.memberId = await fetchMemberId()
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -88,11 +88,10 @@ extension LoginWorker: LoginWorkerProtocol {
             let endPoint = loginEndPointFactory.makeKakaoLoginEndPoint(with: socialToken)
             let result = try await provider.request(with: endPoint, authenticationIfNeeded: false)
 
-            authManager.accessToken = result.data?.accessToken
-            authManager.refreshToken = result.data?.refreshToken
-            authManager.isLoggedIn = true
-            authManager.loginType = .kakao
-            authManager.memberID = await fetchMemberId()
+            authManager.login(accessToken: result.data?.accessToken,
+                              refreshToken: result.data?.refreshToken,
+                              memberID: await fetchMemberId(),
+                              loginType: .kakao)
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
@@ -118,11 +117,10 @@ extension LoginWorker: LoginWorkerProtocol {
             let endPoint: EndPoint = loginEndPointFactory.makeAppleLoginEndPoint(with: identityToken)
             let result: EndPoint<Response<LoginDTO>>.Response = try await provider.request(with: endPoint, authenticationIfNeeded: false)
 
-            authManager.accessToken = result.data?.accessToken
-            authManager.refreshToken = result.data?.refreshToken
-            authManager.isLoggedIn = true
-            authManager.loginType = .apple
-            authManager.memberID = await fetchMemberId()
+            authManager.login(accessToken: result.data?.accessToken,
+                              refreshToken: result.data?.refreshToken,
+                              memberID: await fetchMemberId(),
+                              loginType: .apple)
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -91,6 +91,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken
             authManager.isLoggedIn = true
+            authManager.loginType = .kakao
             authManager.memberId = await fetchMemberId()
             return true
         } catch {
@@ -120,6 +121,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.accessToken = result.data?.accessToken
             authManager.refreshToken = result.data?.refreshToken
             authManager.isLoggedIn = true
+            authManager.loginType = .apple
             authManager.memberId = await fetchMemberId()
             return true
         } catch {

--- a/iOS/Layover/Layover/Scenes/Setting/SettingInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Setting/SettingInteractor.swift
@@ -48,6 +48,7 @@ final class SettingInteractor: SettingBusinessLogic, SettingDataStore {
     func performUserWithdraw(request: SettingModels.Withdraw.Request) -> Task<Bool, Never> {
         Task {
             guard (await userWorker?.withdraw()) != nil else { return false }
+            userWorker?.logout()
             await MainActor.run {
                 presenter?.presentUserWithdrawConfirmed(with: Models.Withdraw.Response())
             }

--- a/iOS/Layover/Layover/Scenes/Setting/SettingViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Setting/SettingViewController.swift
@@ -36,7 +36,7 @@ final class SettingViewController: BaseViewController {
     }()
 
     private lazy var withdrawAlertController: UIAlertController = {
-        let alertController = UIAlertController(title: "회원탈퇴", message: "7일내로 재로그인시 계정이 복구됩니다.\n정말 탈퇴하시겠어요?", preferredStyle: .alert)
+        let alertController = UIAlertController(title: "회원탈퇴", message: "7일 내로 재로그인시 계정이 복구됩니다.\n정말 탈퇴하시겠어요?", preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "탈퇴", style: .destructive, handler: { [weak self] _ in
             self?.interactor?.performUserWithdraw(request: Models.Withdraw.Request())
         }))

--- a/iOS/Layover/Layover/Scenes/Setting/SettingViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Setting/SettingViewController.swift
@@ -36,7 +36,7 @@ final class SettingViewController: BaseViewController {
     }()
 
     private lazy var withdrawAlertController: UIAlertController = {
-        let alertController = UIAlertController(title: "회원탈퇴", message: "회원탈퇴 하시겠습니까?", preferredStyle: .alert)
+        let alertController = UIAlertController(title: "회원탈퇴", message: "7일내로 재로그인시 계정이 복구됩니다.\n정말 탈퇴하시겠어요?", preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "탈퇴", style: .destructive, handler: { [weak self] _ in
             self?.interactor?.performUserWithdraw(request: Models.Withdraw.Request())
         }))

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
@@ -50,11 +50,10 @@ extension SignUpWorker: SignUpWorkerProtocol {
                 return false
             }
 
-            authManager.accessToken = data.accessToken
-            authManager.refreshToken = data.refreshToken
-            authManager.isLoggedIn = true
-            authManager.loginType = .kakao
-            authManager.memberID = await fetchMemberId()
+            authManager.login(accessToken: data.accessToken,
+                              refreshToken: data.refreshToken,
+                              memberID: await fetchMemberId(),
+                              loginType: .kakao)
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
@@ -71,11 +70,10 @@ extension SignUpWorker: SignUpWorkerProtocol {
                 os_log(.error, log: .default, "Failed to sign up with error: %@", responseData.message)
                 return false
             }
-            authManager.accessToken = data.accessToken
-            authManager.refreshToken = data.refreshToken
-            authManager.isLoggedIn = true
-            authManager.loginType = .apple
-            authManager.memberID = await fetchMemberId()
+            authManager.login(accessToken: data.accessToken,
+                              refreshToken: data.refreshToken,
+                              memberID: await fetchMemberId(),
+                              loginType: .apple)
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
@@ -54,10 +54,10 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.refreshToken = data.refreshToken
             authManager.isLoggedIn = true
             authManager.loginType = .kakao
-            authManager.memberId = await fetchMemberId()
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
-            os_log(.error, log: .default, "Failed to sign up with error: %@", error.localizedDescription)
+            os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
             return false
         }
     }
@@ -75,10 +75,10 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.refreshToken = data.refreshToken
             authManager.isLoggedIn = true
             authManager.loginType = .apple
-            authManager.memberId = await fetchMemberId()
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
-            os_log(.error, log: .default, "Failed to sign up with error: %@", error.localizedDescription)
+            os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
             return false
         }
     }
@@ -88,12 +88,12 @@ extension SignUpWorker: SignUpWorkerProtocol {
         do {
             let responseData = try await provider.request(with: endPoint)
             guard let data = responseData.data else {
-                os_log(.error, log: .default, "Failed to fetch member id with error: %@", responseData.message)
+                os_log(.error, log: .data, "Failed to fetch member id with error: %@", responseData.message)
                 return nil
             }
             return data.id
         } catch {
-            os_log(.error, log: .default, "Failed to fetch member id with error: %@", error.localizedDescription)
+            os_log(.error, log: .data, "Failed to fetch member id with error: %@", error.localizedDescription)
             return nil
         }
     }

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
@@ -53,6 +53,7 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.accessToken = data.accessToken
             authManager.refreshToken = data.refreshToken
             authManager.isLoggedIn = true
+            authManager.loginType = .kakao
             authManager.memberId = await fetchMemberId()
             return true
         } catch {
@@ -73,6 +74,7 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.accessToken = data.accessToken
             authManager.refreshToken = data.refreshToken
             authManager.isLoggedIn = true
+            authManager.loginType = .apple
             authManager.memberId = await fetchMemberId()
             return true
         } catch {

--- a/iOS/Layover/Layover/Services/System.swift
+++ b/iOS/Layover/Layover/Services/System.swift
@@ -10,10 +10,10 @@ import Foundation
 
 enum System {
 
-    @UserDefaultStored(key: UserDefaultKey.hasBeenLaunchedBefore, defaultValue: false) static var hasBeenLaunchedBefore: Bool
+    @UserDefaultStored(key: UserDefaultKey.hasBeenLaunchedBefore, defaultValue: false) static var hasBeenLaunchedBefore: Bool?
 
     static func isFirstLaunch() -> Bool {
-        if !hasBeenLaunchedBefore {
+        if hasBeenLaunchedBefore == false {
             hasBeenLaunchedBefore = true
             return true
         }

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -41,4 +41,5 @@ enum UserDefaultKey {
     static let isLoggedIn = "isLoggedIn"
     static let hasBeenLaunchedBefore = "hasBeenLaunchedBefore"
     static let memberId = "memberId"
+    static let loginType = "loginType"
 }

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -31,4 +31,5 @@ struct UserDefaultStored<T> {
 enum UserDefaultKey {
     static let isLoggedIn = "isLoggedIn"
     static let hasBeenLaunchedBefore = "hasBeenLaunchedBefore"
+    static let memberId = "memberId"
 }

--- a/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
+++ b/iOS/Layover/Layover/Services/UserDefaults/UserDefaultStored.swift
@@ -9,21 +9,30 @@
 import Foundation
 
 @propertyWrapper
-struct UserDefaultStored<T> {
+struct UserDefaultStored<T: Codable> {
     private let key: String
-    private let defaultValue: T
+    private let defaultValue: T?
 
-    init(key: String, defaultValue: T) {
+    init(key: String, defaultValue: T?) {
         self.key = key
         self.defaultValue = defaultValue
     }
 
-    var wrappedValue: T {
+    var wrappedValue: T? {
         get {
-            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+            if let savedData = UserDefaults.standard.object(forKey: key) as? Data {
+                let decoder = JSONDecoder()
+                if let loadedObject = try? decoder.decode(T.self, from: savedData) {
+                    return loadedObject
+                }
+            }
+            return defaultValue
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: key)
+            let encoder = JSONEncoder()
+            if let encodedObject = try? encoder.encode(newValue) {
+                UserDefaults.standard.set(encodedObject, forKey: key)
+            }
         }
     }
 }

--- a/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
@@ -16,5 +16,5 @@ final class StubAuthManager: AuthManagerProtocol {
     var refreshToken: String? = "Fake Refresh Token"
     var isLoggedIn: Bool? = true
     var loginType: LoginType? = .kakao
-    var memberId: Int? = 0
+    var memberID: Int? = -1
 }

--- a/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
@@ -15,12 +15,5 @@ final class StubAuthManager: AuthManagerProtocol {
     var accessToken: String? = "Fake Access Token"
     var refreshToken: String? = "Fake Refresh Token"
     var isLoggedIn: Bool = true
-
-    // MARK: Methods
-
-    func logout() {
-        accessToken = nil
-        refreshToken = nil
-        isLoggedIn = false
-    }
+    var memberId: Int? = 0
 }

--- a/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
@@ -15,5 +15,6 @@ final class StubAuthManager: AuthManagerProtocol {
     var accessToken: String? = "Fake Access Token"
     var refreshToken: String? = "Fake Refresh Token"
     var isLoggedIn: Bool? = true
+    var loginType: LoginType? = .kakao
     var memberId: Int? = 0
 }

--- a/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/StubAuthManager.swift
@@ -14,6 +14,6 @@ final class StubAuthManager: AuthManagerProtocol {
 
     var accessToken: String? = "Fake Access Token"
     var refreshToken: String? = "Fake Refresh Token"
-    var isLoggedIn: Bool = true
+    var isLoggedIn: Bool? = true
     var memberId: Int? = 0
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 탈퇴 시 안내창 문구 수정
- UserDefaultsWrapper 객체 아카이빙/언아카이빙 방식으로 변경
- 가입, 로그인 시 MemberId/LoginType UserDefaults에 저장하도록 변경

#### 📌 변경 사항
> [!NOTE]
> UserDefaultsWrapper 객체 아카이빙 방식으로 변경

- 기존 구현으로는 UserDefaults에 옵셔널을 저장하기가 어려워서 JSONDecoder/Encoder를 이용한 객체 아카이빙 방식으로 변경하였습니다.
- 이제 반드시 UserDefaults 타입은 옵셔널로 선언해야하고, 꺼내쓸 때 값을 명확히 비교해야 합니다. (변경 코드 참고)

> [!NOTE]
> 회원 가입, 로그인 시 MemberId, LoginType 저장

- 회원 가입, 로그인 시 본인의 MemberId와 로그인 종류를 저장하도록 했습니다.
- AuthManager에서 꺼내어 사용하시면 됩니다.

##### 📸 ScreenShot
<img src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/e3dc8215-f6d7-4c9b-a0b6-aea2a7c3fa17" width=40%>

#### Linked Issue
close #284
