### PR TITLE
bug: 업로드, 프로필 편집시 PHPicker 이전에 선택한 것 reset

### DIFF
--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2023 CodeBomber. All rights reserved.
 //
 
-
 import UIKit
 import PhotosUI
 import OSLog
@@ -23,7 +22,7 @@ final class EditProfileViewController: BaseViewController {
     // MARK: - UI Components
 
     private lazy var phPickerViewController: PHPickerViewController = {
-        var configuration = PHPickerConfiguration()
+        var configuration = PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())
         configuration.filter = .images
         configuration.selectionLimit = 1
         let phPickerViewController = PHPickerViewController(configuration: configuration)
@@ -263,6 +262,7 @@ extension EditProfileViewController: PHPickerViewControllerDelegate {
                     }
                 }.resume()
             }
+            picker.deselectAssets(withIdentifiers: results.compactMap(\.assetIdentifier))
         }
     }
 }

--- a/iOS/Layover/Layover/Scenes/UploadPost/VideoPickerManager.swift
+++ b/iOS/Layover/Layover/Scenes/UploadPost/VideoPickerManager.swift
@@ -19,7 +19,7 @@ final class VideoPickerManager: NSObject, PHPickerViewControllerDelegate {
     weak var videoPickerDelegate: VideoPickerDelegate?
 
     let phPickerViewController: PHPickerViewController = {
-        var configuration = PHPickerConfiguration()
+        var configuration = PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())
         configuration.preferredAssetRepresentationMode = .current
         configuration.filter = .videos
         configuration.selectionLimit = 1
@@ -41,7 +41,6 @@ final class VideoPickerManager: NSObject, PHPickerViewControllerDelegate {
             self.phPickerViewController.dismiss(animated: true)
             return
         }
-
         _ = result.itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, error in
             if error != nil {
                 Task {
@@ -55,6 +54,7 @@ final class VideoPickerManager: NSObject, PHPickerViewControllerDelegate {
                 self.videoPickerDelegate?.didFinishPickingVideo(url)
             }
         }
+        picker.deselectAssets(withIdentifiers: results.compactMap(\.assetIdentifier))
     }
 
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.

- 처음에는 delegate result에서 identifier를 알 수 있는 방법을 찾지 못해서 우선 사용할 때마다 PHPicekr 인스턴스를 만들어서 사용하도록 했습니다 ! delegate result로 오는 item들은 모두 identifier가 nil이더군요..
- 인환님께서 deselect 메서드 못쓰냐고해서 찾아보니까 `PHPhotoLibrary.shared`를 사용해서 `PHPicker의 Configuration`을 구성하면 delegate의 result로 identifier를 정상적으로 얻어오는 걸 알 수 있었어요!
- `PHPhotoLibrary.shared`은 싱글톤으로 Photos 앱에 의해 관리되는 모든 사진과 비디오의 집합이라고 생각하시면 될 것 같습니다 !

##### 📸 ScreenShot
작동, 구현화면

https://github.com/boostcampwm2023/iOS09-Layover/assets/70168249/5ba71eb7-ebd5-4d86-85ad-c7e1f0d75f2d



#### Linked Issue
close #287 
