### PR TITLE
feat: 지도에서 영상 검색시 반경 radius 표시

### DIFF
--- a/iOS/Layover/Layover/Scenes/Map/MapModels.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapModels.swift
@@ -10,6 +10,8 @@ import Foundation
 
 enum MapModels {
 
+    static let searchRadiusInMeters: Double = 10000
+
     struct DisplayedPost: Hashable {
         let boardID: Int
         let thumbnailImageData: Data?

--- a/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Map/MapViewController.swift
@@ -278,6 +278,17 @@ extension MapViewController: VideoPickerDelegate {
         }
     }
 
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if overlay is MKCircle {
+            let renderer = MKCircleRenderer(overlay: overlay)
+            renderer.strokeColor = UIColor.primaryPurple.withAlphaComponent(0.6)
+            renderer.fillColor = UIColor.primaryPurple.withAlphaComponent(0.3)
+            renderer.lineWidth = 2.0
+            return renderer
+        }
+        return MKOverlayRenderer()
+    }
+
 }
 
 // MARK: - MapDisplayLogic
@@ -293,6 +304,10 @@ extension MapViewController: MapDisplayLogic {
         carouselDatasource.apply(snapshot)
 
         mapView.removeAnnotations(mapView.annotations)
+        mapView.removeOverlays(mapView.overlays)
+
+        let circleOverlay = MKCircle(center: mapView.centerCoordinate, radius: Models.searchRadiusInMeters)
+        mapView.addOverlay(circleOverlay, level: .aboveLabels)
         viewModel.displayedPosts.forEach { createMapAnnotation(post: $0) }
     }
 


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
해당 pr에서 작업한 내역을 적어주세요.

- 검색시 좌표 중심점에 10km 반경의 MKCircle을 추가해서 사용성을 개선했습니다.
- [mapView Delegate](https://developer.apple.com/documentation/mapkit/mkmapviewdelegate/1452203-mapview)를 사용하여,
- 지도에 오버레이를 표시할 때 마다 오버레이를 그릴 [렌더러 객체](https://developer.apple.com/documentation/mapkit/mkoverlayrenderer)를 만들어서 오버레이 콘텐츠를 만들도록 했습니다. 


```swift
    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
        if overlay is MKCircle {
            let renderer = MKCircleRenderer(overlay: overlay)
            renderer.strokeColor = UIColor.primaryPurple.withAlphaComponent(0.6)
            renderer.fillColor = UIColor.primaryPurple.withAlphaComponent(0.3)
            renderer.lineWidth = 2.0
            return renderer
        }
        return MKOverlayRenderer()
    }
```

##### 📸 ScreenShot
작동, 구현화면


https://github.com/boostcampwm2023/iOS09-Layover/assets/70168249/0c09fcdf-95e4-4c6b-b33b-9e1a51b5cd52



#### Linked Issue
close #291 
