### PR TITLE
chore: 신고 삭제 로직 분리

### DIFF
--- a/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/Cell/PlaybackCell.swift
@@ -16,7 +16,7 @@ final class PlaybackCell: UICollectionViewCell {
 
     weak var delegate: PlaybackViewControllerDelegate?
 
-    private var memberID: Int?
+    private (set) var memberID: Int?
 
     let playbackView: PlaybackView = PlaybackView()
 

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackInteractor.swift
@@ -225,8 +225,11 @@ final class PlaybackInteractor: PlaybackBusinessLogic, PlaybackDataStore {
     }
 
     func setSeeMoreButton() {
-        guard let parentView else { return }
-        let response: Models.SetSeemoreButton.Response = Models.SetSeemoreButton.Response(parentView: parentView)
+        guard let worker,
+              let currentCellMemberID: Int = previousCell?.memberID
+        else { return }
+        let buttonType: Models.SetSeemoreButton.ButtonType = worker.isMyVideo(currentCellMemberID: currentCellMemberID) ? .delete : .report
+        let response: Models.SetSeemoreButton.Response = Models.SetSeemoreButton.Response(buttonType: buttonType)
         presenter?.presentSetSeemoreButton(with: response)
     }
 

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackModels.swift
@@ -179,7 +179,7 @@ enum PlaybackModels {
         }
 
         struct Response {
-            let parentView: ParentView
+            let buttonType: ButtonType
         }
 
         struct ViewModel {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackPresenter.swift
@@ -112,8 +112,7 @@ final class PlaybackPresenter: PlaybackPresentationLogic {
     }
 
     func presentSetSeemoreButton(with response: PlaybackModels.SetSeemoreButton.Response) {
-        let buttonType: Models.SetSeemoreButton.ButtonType = response.parentView == .myProfile ? .delete : .report
-        viewController?.setSeemoreButton(viewModel: Models.SetSeemoreButton.ViewModel(buttonType: buttonType))
+        viewController?.setSeemoreButton(viewModel: Models.SetSeemoreButton.ViewModel(buttonType: response.buttonType))
     }
 
     func presentDeleteVideo(with response: PlaybackModels.DeletePlaybackVideo.Response) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -287,14 +287,6 @@ extension PlaybackViewController: PlaybackDisplayLogic {
     }
 
     func setSeemoreButton(viewModel: Models.SetSeemoreButton.ViewModel) {
-//        guard let button = seemoreButton.customView as? UIButton else { return }
-//        switch viewModel.buttonType {
-//        case .delete:
-//            button.addTarget(self, action: #selector(deleteButtonDidTap), for: .touchUpInside)
-//        case .report:
-//            button.addTarget(self, action: #selector(reportButtonDidTap), for: .touchUpInside)
-//        }
-//        self.navigationItem.rightBarButtonItem = seemoreButton
         switch viewModel.buttonType {
         case .delete:
             deleteButtonDidTap()

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -138,11 +138,17 @@ final class PlaybackViewController: BaseViewController {
 
     override func setUI() {
         super.setUI()
-        interactor?.setSeeMoreButton()
+        setSeeMoreButton()
         self.navigationController?.navigationBar.tintColor = .layoverWhite
     }
 
-    @objc private func reportButtonDidTap() {
+    private func setSeeMoreButton() {
+        guard let button = seemoreButton.customView as? UIButton else { return }
+        button.addTarget(self, action: #selector(seeMoreButtonDidTap), for: .touchUpInside)
+        self.navigationItem.rightBarButtonItem = seemoreButton
+    }
+
+    private func reportButtonDidTap() {
         let alert: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let reportAction: UIAlertAction = UIAlertAction(title: "신고", style: .destructive, handler: {
             [weak self] _ in
@@ -159,7 +165,7 @@ final class PlaybackViewController: BaseViewController {
         })
     }
 
-    @objc private func deleteButtonDidTap() {
+    private func deleteButtonDidTap() {
         let visibleIndexPaths = playbackCollectionView.indexPathsForVisibleItems
         if visibleIndexPaths.count > 1 { return }
         guard let currentItemIndex = visibleIndexPaths.first else { return }
@@ -179,6 +185,10 @@ final class PlaybackViewController: BaseViewController {
         present(alert, animated: true, completion: {
             self.interactor?.leavePlaybackView()
         })
+    }
+
+    @objc private func seeMoreButtonDidTap() {
+        interactor?.setSeeMoreButton()
     }
 }
 
@@ -277,14 +287,20 @@ extension PlaybackViewController: PlaybackDisplayLogic {
     }
 
     func setSeemoreButton(viewModel: Models.SetSeemoreButton.ViewModel) {
-        guard let button = seemoreButton.customView as? UIButton else { return }
+//        guard let button = seemoreButton.customView as? UIButton else { return }
+//        switch viewModel.buttonType {
+//        case .delete:
+//            button.addTarget(self, action: #selector(deleteButtonDidTap), for: .touchUpInside)
+//        case .report:
+//            button.addTarget(self, action: #selector(reportButtonDidTap), for: .touchUpInside)
+//        }
+//        self.navigationItem.rightBarButtonItem = seemoreButton
         switch viewModel.buttonType {
         case .delete:
-            button.addTarget(self, action: #selector(deleteButtonDidTap), for: .touchUpInside)
+            deleteButtonDidTap()
         case .report:
-            button.addTarget(self, action: #selector(reportButtonDidTap), for: .touchUpInside)
+            reportButtonDidTap()
         }
-        self.navigationItem.rightBarButtonItem = seemoreButton
     }
 
     func deleteVideo(viewModel: PlaybackModels.DeletePlaybackVideo.ViewModel) {

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackWorker.swift
@@ -19,6 +19,7 @@ protocol PlaybackWorkerProtocol {
     func fetchHomePosts() async -> [Post]?
     func fetchProfilePosts(profileID: Int?, page: Int) async -> [Post]?
     func fetchTagPosts(selectedTag: String, page: Int) async -> [Post]?
+    func isMyVideo(currentCellMemberID: Int) -> Bool
 }
 
 final class PlaybackWorker: PlaybackWorkerProtocol {
@@ -28,17 +29,19 @@ final class PlaybackWorker: PlaybackWorkerProtocol {
     typealias Models = PlaybackModels
 
     private let provider: ProviderType
+    private let authManager: AuthManagerProtocol
     private let defaultPostManagerEndPointFactory: PostManagerEndPointFactory
     private let defaultPostEndPointFactory: PostEndPointFactory
     private let defaultUserEndPointFactory: UserEndPointFactory
 
     // MARK: - Methods
 
-    init(provider: ProviderType = Provider(), defaultPostManagerEndPointFactory: PostManagerEndPointFactory = DefaultPostManagerEndPointFactory(), defaultPostEndPointFactory: PostEndPointFactory = DefaultPostEndPointFactory(), defaultUserEndPointFactory: UserEndPointFactory = DefaultUserEndPointFactory()) {
+    init(provider: ProviderType = Provider(), authManager: AuthManagerProtocol = AuthManager.shared, defaultPostManagerEndPointFactory: PostManagerEndPointFactory = DefaultPostManagerEndPointFactory(), defaultPostEndPointFactory: PostEndPointFactory = DefaultPostEndPointFactory(), defaultUserEndPointFactory: UserEndPointFactory = DefaultUserEndPointFactory()) {
         self.provider = provider
         self.defaultPostManagerEndPointFactory = defaultPostManagerEndPointFactory
         self.defaultPostEndPointFactory = defaultPostEndPointFactory
         self.defaultUserEndPointFactory = defaultUserEndPointFactory
+        self.authManager = authManager
     }
 
     func makeInfiniteScroll(posts: [Post]) -> [Post] {
@@ -117,5 +120,10 @@ final class PlaybackWorker: PlaybackWorkerProtocol {
             os_log(.error, log: .data, "Failed to fetch posts: %@", error.localizedDescription)
             return nil
         }
+    }
+
+    func isMyVideo(currentCellMemberID: Int) -> Bool {
+        let myMemberID = authManager.memberID
+        return currentCellMemberID == myMemberID
     }
 }

--- a/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
@@ -20,10 +20,6 @@ final class MockPlaybackWorker: PlaybackWorkerProtocol {
     private let authManager: AuthManagerProtocol
 
     // MARK: - Methods
-
-//    init(provider: ProviderType = Provider(session: .initMockSession())) {
-//        self.provider = provider
-//    }
     
     init(provider: ProviderType = Provider(session: .initMockSession()), authManager: AuthManagerProtocol = StubAuthManager()) {
         self.provider = provider

--- a/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
@@ -17,13 +17,19 @@ final class MockPlaybackWorker: PlaybackWorkerProtocol {
     typealias Models = PlaybackModels
 
     private let provider: ProviderType
+    private let authManager: AuthManagerProtocol
 
     // MARK: - Methods
 
-    init(provider: ProviderType = Provider(session: .initMockSession())) {
-        self.provider = provider
-    }
+//    init(provider: ProviderType = Provider(session: .initMockSession())) {
+//        self.provider = provider
+//    }
     
+    init(provider: ProviderType = Provider(session: .initMockSession()), authManager: AuthManagerProtocol = StubAuthManager()) {
+        self.provider = provider
+        self.authManager = authManager
+    }
+
     func makeInfiniteScroll(posts: [Post]) -> [Post] {
         guard let tempLastVideo: Post = posts.last,
               let tempFirstVideo: Post = posts.first
@@ -174,6 +180,10 @@ final class MockPlaybackWorker: PlaybackWorkerProtocol {
             os_log(.error, log: .data, "%@", error.localizedDescription)
             return nil
         }
+    }
+
+    func isMyVideo(currentCellMemberID: Int) -> Bool {
+        return currentCellMemberID == authManager.memberID
     }
 
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
authManager에서 memberID가져와 비교해 본인 것이면 삭제, 다른 사람 것이면 신고가 되도록 했습니다.

##### 📸 ScreenShot

https://github.com/boostcampwm2023/iOS09-Layover/assets/44396392/2d727dd7-c88e-44bf-8b08-c1f42471f85d


#### Linked Issue
close #295 
