### PR TITLE
bug: memberID 요청 전, 토큰을 저장하지 않았던 버그 수정

### DIFF
--- a/iOS/Layover/Layover/Network/AuthManager.swift
+++ b/iOS/Layover/Layover/Network/AuthManager.swift
@@ -13,7 +13,7 @@ protocol AuthManagerProtocol: AnyObject {
     var loginType: LoginType? { get set }
     var memberID: Int? { get set }
 
-    func login(accessToken: String?, refreshToken: String?, memberID: Int?, loginType: LoginType?)
+    func login(accessToken: String?, refreshToken: String?, loginType: LoginType?)
     func logout()
 }
 
@@ -23,10 +23,9 @@ enum LoginType: String, Codable {
 }
 
 extension AuthManagerProtocol {
-    func login(accessToken: String?, refreshToken: String?, memberID: Int?, loginType: LoginType?) {
+    func login(accessToken: String?, refreshToken: String?, loginType: LoginType?) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
-        self.memberID = memberID
         self.loginType = loginType
         isLoggedIn = true
     }

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -90,8 +90,8 @@ extension LoginWorker: LoginWorkerProtocol {
 
             authManager.login(accessToken: result.data?.accessToken,
                               refreshToken: result.data?.refreshToken,
-                              memberID: await fetchMemberId(),
                               loginType: .kakao)
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
@@ -119,8 +119,8 @@ extension LoginWorker: LoginWorkerProtocol {
 
             authManager.login(accessToken: result.data?.accessToken,
                               refreshToken: result.data?.refreshToken,
-                              memberID: await fetchMemberId(),
                               loginType: .apple)
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
+++ b/iOS/Layover/Layover/Scenes/Login/LoginWorker.swift
@@ -91,7 +91,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.login(accessToken: result.data?.accessToken,
                               refreshToken: result.data?.refreshToken,
                               loginType: .kakao)
-            authManager.memberID = await fetchMemberId()
+            authManager.memberID = await fetchMemberID()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
@@ -120,7 +120,7 @@ extension LoginWorker: LoginWorkerProtocol {
             authManager.login(accessToken: result.data?.accessToken,
                               refreshToken: result.data?.refreshToken,
                               loginType: .apple)
-            authManager.memberID = await fetchMemberId()
+            authManager.memberID = await fetchMemberID()
             return true
         } catch {
             os_log(.error, log: .data, "%@", error.localizedDescription)
@@ -128,7 +128,7 @@ extension LoginWorker: LoginWorkerProtocol {
         }
     }
 
-    private func fetchMemberId() async -> Int? {
+    private func fetchMemberID() async -> Int? {
         let endPoint = userEndPointFactory.makeUserInformationEndPoint(with: nil)
         do {
             let responseData = try await provider.request(with: endPoint)

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
@@ -52,8 +52,8 @@ extension SignUpWorker: SignUpWorkerProtocol {
 
             authManager.login(accessToken: data.accessToken,
                               refreshToken: data.refreshToken,
-                              memberID: await fetchMemberId(),
                               loginType: .kakao)
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
@@ -72,8 +72,8 @@ extension SignUpWorker: SignUpWorkerProtocol {
             }
             authManager.login(accessToken: data.accessToken,
                               refreshToken: data.refreshToken,
-                              memberID: await fetchMemberId(),
                               loginType: .apple)
+            authManager.memberID = await fetchMemberId()
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)

--- a/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
+++ b/iOS/Layover/Layover/Scenes/SignUpScene/SignUpWorker.swift
@@ -53,7 +53,7 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.login(accessToken: data.accessToken,
                               refreshToken: data.refreshToken,
                               loginType: .kakao)
-            authManager.memberID = await fetchMemberId()
+            authManager.memberID = await fetchMemberID()
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
@@ -73,7 +73,7 @@ extension SignUpWorker: SignUpWorkerProtocol {
             authManager.login(accessToken: data.accessToken,
                               refreshToken: data.refreshToken,
                               loginType: .apple)
-            authManager.memberID = await fetchMemberId()
+            authManager.memberID = await fetchMemberID()
             return true
         } catch {
             os_log(.error, log: .data, "Failed to sign up with error: %@", error.localizedDescription)
@@ -81,7 +81,7 @@ extension SignUpWorker: SignUpWorkerProtocol {
         }
     }
 
-    private func fetchMemberId() async -> Int? {
+    private func fetchMemberID() async -> Int? {
         let endPoint = userEndPointFactory.makeUserInformationEndPoint(with: nil)
         do {
             let responseData = try await provider.request(with: endPoint)


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- memberID 요청 전, 토큰을 먼저 저장하지 않고 요청을 보냈던 오류를 수정했습니다.

#### 📌 변경 사항
- 로그인 메서드에서 memberID 필드를 분리했습니다.

#### Linked Issue
close #312 
