### PR TITLE
feat: 프로필 뷰에서 업로드 중인 영상 로딩 처리, 각종 버그 수정

### DIFF
--- a/iOS/Layover/Layover/Models/Board.swift
+++ b/iOS/Layover/Layover/Models/Board.swift
@@ -16,4 +16,5 @@ struct Board {
     let videoURL: URL?
     let latitude: Double
     let longitude: Double
+    let status: BoardStatus
 }

--- a/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
@@ -14,12 +14,34 @@ struct BoardDTO: Decodable {
     let videoThumbnailURL: String
     let latitude, longitude: Double
     let title, content: String
+    let status: BoardStatus
+
+    enum BoardStatus: String, Decodable {
+        case running
+        case waiting
+        case failure
+        case complete
+        case deleted
+        case inactive
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+
+            if let value = BoardStatus(rawValue: rawValue.lowercased()) {
+                self = value
+            } else {
+                self = .inactive
+            }
+        }
+    }
 
     enum CodingKeys: String, CodingKey {
         case id
         case encodedVideoURL = "encoded_video_url"
         case videoThumbnailURL = "video_thumbnail_url"
         case latitude, longitude, title, content
+        case status
     }
 }
 

--- a/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
+++ b/iOS/Layover/Layover/Network/DTOs/BoardDTO.swift
@@ -16,32 +16,32 @@ struct BoardDTO: Decodable {
     let title, content: String
     let status: BoardStatus
 
-    enum BoardStatus: String, Decodable {
-        case running
-        case waiting
-        case failure
-        case complete
-        case deleted
-        case inactive
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            let rawValue = try container.decode(String.self)
-
-            if let value = BoardStatus(rawValue: rawValue.lowercased()) {
-                self = value
-            } else {
-                self = .inactive
-            }
-        }
-    }
-
     enum CodingKeys: String, CodingKey {
         case id
         case encodedVideoURL = "encoded_video_url"
         case videoThumbnailURL = "video_thumbnail_url"
         case latitude, longitude, title, content
         case status
+    }
+}
+
+enum BoardStatus: String, Decodable {
+    case running
+    case waiting
+    case failure
+    case complete
+    case deleted
+    case inactive
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+
+        if let value = BoardStatus(rawValue: rawValue.lowercased()) {
+            self = value
+        } else {
+            self = .inactive
+        }
     }
 }
 
@@ -54,7 +54,8 @@ extension BoardDTO {
             thumbnailImageURL: URL(string: videoThumbnailURL),
             videoURL: URL(string: encodedVideoURL),
             latitude: latitude,
-            longitude: longitude
+            longitude: longitude,
+            status: status
         )
     }
 }

--- a/iOS/Layover/Layover/Network/Mock/MockData/PostList.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/PostList.json
@@ -16,7 +16,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "최강 아이돌",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["나도몰라요", "너도몰라요"]
         },
@@ -34,7 +35,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "프로듀스 101",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그", "해시태그2"]
         },
@@ -52,7 +54,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "프로미스 나인",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그1", "해시태그2"]
         },
@@ -70,7 +73,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "아이즈원",
-                "content" : "게시글 설명2"
+                "content" : "게시글 설명2",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그1", "해시태그6"]
         },
@@ -88,7 +92,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "아이즈원",
-                "content" : "게시글 설명2"
+                "content" : "게시글 설명2",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그1", "해시태그6"]
         }

--- a/iOS/Layover/Layover/Network/Mock/MockData/PostListMore.json
+++ b/iOS/Layover/Layover/Network/Mock/MockData/PostListMore.json
@@ -16,7 +16,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "최강 아이돌",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["나도몰라요", "너도몰라요"]
         },
@@ -34,7 +35,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "프로듀스 101",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그", "해시태그2"]
         },
@@ -52,7 +54,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "프로미스 나인",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그1", "해시태그2"]
         },
@@ -70,7 +73,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "아이즈원",
-                "content" : "게시글 설명2"
+                "content" : "게시글 설명2",
+                "status": "COMPLETE"
             },
             "tag" : ["해시태그1", "해시태그6"]
         }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -141,22 +141,24 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
                 return false
             }
 
-            // 이미지 변경 시도
-            if let profileImageData = request.profileImageData, let profileImageExtension = request.profileImageExtension {
-                guard await profileImageEditRequest(into: profileImageData, fileExtension: profileImageExtension) else {
-                    await MainActor.run {
-                        presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
+            // 이미지 변경 요청
+            if request.profileImageChanged {
+                if let profileImageData = request.profileImageData, let profileImageExtension = request.profileImageExtension {
+                    guard await profileImageEditRequest(into: profileImageData, fileExtension: profileImageExtension) else {
+                        await MainActor.run {
+                            presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
+                        }
+                        return false
                     }
-                    return false
-                }
-            } else { // 이미지 변경이 없는 경우 이미지 삭제 시도
-                guard await userWorker?.setProfileImageDefault() == true else {
-                    await MainActor.run {
-                        presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
+                } else { // 이미지 데이터 없는 경우 이미지 삭제 시도
+                    guard await userWorker?.setProfileImageDefault() == true else {
+                        await MainActor.run {
+                            presenter?.presentProfile(with: Models.EditProfile.Response(isSuccess: false))
+                        }
+                        return false
                     }
-                    return false
+                    profileImageData = nil
                 }
-                profileImageData = nil
             }
 
             await MainActor.run {
@@ -168,7 +170,7 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
 
     private func nicknameEditRequest(into nickname: String) async -> Bool {
         if self.nickname != nickname {
-            guard let response = await userWorker?.modifyNickname(to: nickname) else {
+            guard await userWorker?.modifyNickname(to: nickname) != nil else {
                 os_log(.error, log: .data, "Edit Profile Error")
                 return false
             }
@@ -178,7 +180,7 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
     }
 
     private func introduceEditRequest(into introduce: String?) async -> Bool {
-        guard let modifyIntroduceResponse = await userWorker?.modifyIntroduce(to: introduce ?? "") else {
+        guard await userWorker?.modifyIntroduce(to: introduce ?? "") != nil else {
             os_log(.error, log: .data, "Edit Profile Error")
             return false
         }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileInteractor.swift
@@ -142,7 +142,7 @@ final class EditProfileInteractor: EditProfileBusinessLogic, EditProfileDataStor
             }
 
             // 이미지 변경 요청
-            if request.profileImageChanged {
+            if request.changeProfileImageNeeded {
                 if let profileImageData = request.profileImageData, let profileImageExtension = request.profileImageExtension {
                     guard await profileImageEditRequest(into: profileImageData, fileExtension: profileImageExtension) else {
                         await MainActor.run {

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -93,6 +93,7 @@ enum EditProfileModels {
         struct Request {
             let nickname: String
             let introduce: String?
+            let profileImageChanged: Bool
             let profileImageData: Data?
             let profileImageExtension: String?
         }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileModels.swift
@@ -93,7 +93,7 @@ enum EditProfileModels {
         struct Request {
             let nickname: String
             let introduce: String?
-            let profileImageChanged: Bool
+            let changeProfileImageNeeded: Bool
             let profileImageData: Data?
             let profileImageExtension: String?
         }

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -95,6 +95,7 @@ final class EditProfileViewController: BaseViewController {
             guard let self else { return }
             self.changedProfileImageData = nil
             self.changedProfileImageExtension = nil
+            self.changeProfileImageNeeded = true
             self.profileImageView.image = UIImage.profile
             self.profileImageDataChanged()
         }
@@ -114,6 +115,7 @@ final class EditProfileViewController: BaseViewController {
     var interactor: EditProfileBusinessLogic?
 
     private var isValidNickname = true
+    private var changeProfileImageNeeded = false
     private var changedProfileImageData: Data?
     private var changedProfileImageExtension: String?
 
@@ -223,7 +225,7 @@ final class EditProfileViewController: BaseViewController {
 
         let request = Models.EditProfile.Request(nickname: nickname,
                                                  introduce: introduce,
-                                                 profileImageChanged: changedProfileImageData != nil,
+                                                 changeProfileImageNeeded: changeProfileImageNeeded,
                                                  profileImageData: changedProfileImageData,
                                                  profileImageExtension: changedProfileImageExtension)
         showLoading()
@@ -253,6 +255,7 @@ extension EditProfileViewController: PHPickerViewControllerDelegate {
                                     self.profileImageView.image = UIImage(contentsOfFile: temporaryCopyFileURL.path())
                                     self.changedProfileImageExtension = pathExtension
                                     self.changedProfileImageData = try? Data(contentsOf: temporaryCopyFileURL)
+                                    self.changeProfileImageNeeded = true
                                     self.profileImageDataChanged()
                                 }
                                 try FileManager.default.removeItem(at: temporaryCopyFileURL)

--- a/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/EditProfile/EditProfileViewController.swift
@@ -223,6 +223,7 @@ final class EditProfileViewController: BaseViewController {
 
         let request = Models.EditProfile.Request(nickname: nickname,
                                                  introduce: introduce,
+                                                 profileImageChanged: changedProfileImageData != nil,
                                                  profileImageData: changedProfileImageData,
                                                  profileImageExtension: changedProfileImageExtension)
         showLoading()

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileConfigurator.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileConfigurator.swift
@@ -19,7 +19,6 @@ final class ProfileConfigurator: Configurator {
     func configure(_ viewController: ViewController) {
         let viewController = viewController
         let interactor = ProfileInteractor()
-//        let worker = MockUserWorker()
         let worker = UserWorker()
         let presenter = ProfilePresenter()
         let router = ProfileRouter()

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
@@ -106,22 +106,22 @@ final class ProfileInteractor: ProfileBusinessLogic, ProfileDataStore {
         }
     }
 
-    private func fetchPosts() async -> [Models.Post] {
+    private func fetchPosts() async -> [Models.DisplayedPost] {
         guard let fetchedPosts = await userWorker?.fetchPosts(at: fetchPostsPage, of: profileId),
               fetchedPosts.count > 0 else {
             return []
         }
         posts += fetchedPosts
 
-        var responsePosts = [Models.Post]()
+        var responsePosts = [Models.DisplayedPost]()
         for post in fetchedPosts {
             guard let thumbnailURL = post.board.thumbnailImageURL,
                   let profileImageData = await userWorker?.fetchImageData(with: thumbnailURL) else {
-                responsePosts.append(.init(id: post.board.identifier, thumbnailImageData: nil))
+                responsePosts.append(.init(id: post.board.identifier, thumbnailImageData: nil, status: post.board.status))
                 continue
             }
 
-            responsePosts.append(Models.Post(id: post.board.identifier, thumbnailImageData: profileImageData))
+            responsePosts.append(Models.DisplayedPost(id: post.board.identifier, thumbnailImageData: profileImageData, status: post.board.status))
         }
 
         return responsePosts

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
@@ -76,7 +76,7 @@ final class ProfileInteractor: ProfileBusinessLogic, ProfileDataStore {
             let response = Models.FetchProfile.Response(userProfile: ProfileModels.Profile(username: userProfile.username,
                                                                                            introduce: userProfile.introduce,
                                                                                            profileImageData: imageData),
-                                                        posts: posts)
+                                                        displayedPosts: posts)
             await MainActor.run {
                 presenter?.presentProfile(with: response)
             }
@@ -96,7 +96,7 @@ final class ProfileInteractor: ProfileBusinessLogic, ProfileDataStore {
                 return false
             }
 
-            let response = Models.FetchMorePosts.Response(posts: fetchedPosts)
+            let response = Models.FetchMorePosts.Response(displayedPosts: fetchedPosts)
 
             await MainActor.run {
                 presenter?.presentMorePosts(with: response)

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileInteractor.swift
@@ -56,11 +56,12 @@ final class ProfileInteractor: ProfileBusinessLogic, ProfileDataStore {
     func fetchProfile(with request: ProfileModels.FetchProfile.Request) -> Task<Bool, Never> {
         fetchPostsPage = 1
         canFetchMorePosts = true
+        posts = []
+        
         return Task {
             guard let userProfile = await userWorker?.fetchProfile(by: profileId) else {
                 return false
             }
-            posts = []
             nickname = userProfile.username
             introduce = userProfile.introduce
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
@@ -16,8 +16,7 @@ enum ProfileModels {
         let profileImageData: Data?
     }
 
-    struct DisplayedPost: Hashable, Identifiable {
-        let uuid = UUID()
+    struct DisplayedPost: Hashable {
         let id: Int
         let thumbnailImageData: Data?
         let status: BoardStatus

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
@@ -29,12 +29,12 @@ enum ProfileModels {
 
         struct Response {
             let userProfile: Profile
-            let posts: [DisplayedPost]
+            let displayedPosts: [DisplayedPost]
         }
 
         struct ViewModel {
             let userProfile: Profile
-            let posts: [DisplayedPost]
+            let displayedPosts: [DisplayedPost]
         }
     }
 
@@ -43,11 +43,11 @@ enum ProfileModels {
         }
 
         struct Response {
-            let posts: [DisplayedPost]
+            let displayedPosts: [DisplayedPost]
         }
 
         struct ViewModel {
-            let posts: [DisplayedPost]
+            let displayedPosts: [DisplayedPost]
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
@@ -16,9 +16,10 @@ enum ProfileModels {
         let profileImageData: Data?
     }
 
-    struct Post: Hashable {
+    struct DisplayedPost: Hashable {
         let id: Int
         let thumbnailImageData: Data?
+        let status: BoardStatus
     }
 
     enum FetchProfile {
@@ -28,12 +29,12 @@ enum ProfileModels {
 
         struct Response {
             let userProfile: Profile
-            let posts: [Post]
+            let posts: [DisplayedPost]
         }
 
         struct ViewModel {
             let userProfile: Profile
-            let posts: [Post]
+            let posts: [DisplayedPost]
         }
     }
 
@@ -42,11 +43,11 @@ enum ProfileModels {
         }
 
         struct Response {
-            let posts: [Post]
+            let posts: [DisplayedPost]
         }
 
         struct ViewModel {
-            let posts: [Post]
+            let posts: [DisplayedPost]
         }
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileModels.swift
@@ -16,7 +16,8 @@ enum ProfileModels {
         let profileImageData: Data?
     }
 
-    struct DisplayedPost: Hashable {
+    struct DisplayedPost: Hashable, Identifiable {
+        let uuid = UUID()
         let id: Int
         let thumbnailImageData: Data?
         let status: BoardStatus

--- a/iOS/Layover/Layover/Scenes/Profile/ProfilePresenter.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfilePresenter.swift
@@ -25,12 +25,12 @@ final class ProfilePresenter: ProfilePresentationLogic {
 
     func presentProfile(with response: Models.FetchProfile.Response) {
         let viewModel = Models.FetchProfile.ViewModel(userProfile: response.userProfile,
-                                                      posts: response.posts)
+                                                      displayedPosts: response.displayedPosts)
         viewController?.displayProfile(viewModel: viewModel)
     }
 
     func presentMorePosts(with response: ProfileModels.FetchMorePosts.Response) {
-        let viewModel = Models.FetchMorePosts.ViewModel(posts: response.posts)
+        let viewModel = Models.FetchMorePosts.ViewModel(displayedPosts: response.displayedPosts)
         viewController?.displayMorePosts(viewModel: viewModel)
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -213,13 +213,13 @@ extension ProfileViewController: ProfileDisplayLogic {
         var snapshot = NSDiffableDataSourceSnapshot<Section, AnyHashable>()
         snapshot.appendSections([.profile, .posts])
         snapshot.appendItems([viewModel.userProfile], toSection: .profile)
-        snapshot.appendItems(viewModel.posts, toSection: .posts)
+        snapshot.appendItems(viewModel.displayedPosts, toSection: .posts)
         collectionViewDatasource?.apply(snapshot)
     }
 
     func displayMorePosts(viewModel: ProfileModels.FetchMorePosts.ViewModel) {
         guard var snapshot = collectionViewDatasource?.snapshot(for: .posts) else { return }
-        snapshot.append(viewModel.posts)
+        snapshot.append(viewModel.displayedPosts)
         collectionViewDatasource?.apply(snapshot, to: .posts)
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -258,7 +258,7 @@ extension ProfileViewController: UICollectionViewDelegate {
         let scrollOffset = scrollView.contentOffset.y
         let height = scrollView.bounds.height
 
-        if scrollOffset > contentHeight - height {
+        if scrollOffset > 0 && scrollOffset > contentHeight - height {
             fetchPosts()
         }
     }

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -268,8 +268,13 @@ extension ProfileViewController: UICollectionViewDelegate {
         case .profile:
             return
         case .posts:
-            guard collectionViewDatasource?.itemIdentifier(for: indexPath) is Models.DisplayedPost else { return }
-            interactor?.showPostDetail(with: Models.ShowPostDetail.Request(startIndex: indexPath.item))
+            guard let post = collectionViewDatasource?.itemIdentifier(for: indexPath) as? Models.DisplayedPost else { return }
+            switch post.status {
+            case .complete:
+                interactor?.showPostDetail(with: Models.ShowPostDetail.Request(startIndex: indexPath.item))
+            default:
+                Toast.shared.showToast(message: "인코딩 중인 영상입니다. 잠시만 기다려주세요!")
+            }
         }
     }
 }

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -234,8 +234,9 @@ extension ProfileViewController: ProfileDisplayLogic {
         snapshot.appendSections([.profile, .posts])
         snapshot.appendItems([viewModel.userProfile], toSection: .profile)
         snapshot.appendItems(viewModel.displayedPosts, toSection: .posts)
-        collectionViewDatasource?.apply(snapshot)
-        refreshControl.endRefreshing()
+        collectionViewDatasource?.apply(snapshot) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
     }
 
     func displayMorePosts(viewModel: ProfileModels.FetchMorePosts.ViewModel) {

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -162,7 +162,9 @@ final class ProfileViewController: BaseViewController {
 
             if let imageData = itemIdentifier.thumbnailImageData,
                let image = UIImage(data: imageData) {
-                cell.configure(image: image)
+                cell.configure(image: image, status: itemIdentifier.status)
+            } else {
+                cell.configure(image: nil, status: itemIdentifier.status)
             }
         }
 

--- a/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/ProfileViewController.swift
@@ -158,7 +158,7 @@ final class ProfileViewController: BaseViewController {
             cell.editButton.addTarget(self, action: #selector(self.editbuttonDidTap), for: .touchUpInside)
         }
 
-        let postCellRegistration = UICollectionView.CellRegistration<ThumbnailCollectionViewCell, Models.Post> { cell, indexPath, itemIdentifier in
+        let postCellRegistration = UICollectionView.CellRegistration<ThumbnailCollectionViewCell, Models.DisplayedPost> { cell, indexPath, itemIdentifier in
 
             if let imageData = itemIdentifier.thumbnailImageData,
                let image = UIImage(data: imageData) {
@@ -177,7 +177,7 @@ final class ProfileViewController: BaseViewController {
             case .posts:
                 return collectionView.dequeueConfiguredReusableCell(using: postCellRegistration,
                                                                     for: indexPath,
-                                                                    item: itemIdentifier as? Models.Post)
+                                                                    item: itemIdentifier as? Models.DisplayedPost)
             }
         }
         collectionView.dataSource = collectionViewDatasource
@@ -247,7 +247,7 @@ extension ProfileViewController: UICollectionViewDelegate {
         case .profile:
             return
         case .posts:
-            guard let post = collectionViewDatasource?.itemIdentifier(for: indexPath) as? Models.Post else { return }
+            guard let post = collectionViewDatasource?.itemIdentifier(for: indexPath) as? Models.DisplayedPost else { return }
             interactor?.showPostDetail(with: Models.ShowPostDetail.Request(startIndex: indexPath.item))
         }
     }

--- a/iOS/Layover/Layover/Scenes/Profile/Views/ThumbnailCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/Views/ThumbnailCollectionViewCell.swift
@@ -19,6 +19,14 @@ final class ThumbnailCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
 
+    private let spinner: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .primaryPurple
+        indicator.hidesWhenStopped = true
+        indicator.stopAnimating()
+        return indicator
+    }()
+
     // MARK: - Object Lifecycle
 
     override init(frame: CGRect) {
@@ -35,8 +43,15 @@ final class ThumbnailCollectionViewCell: UICollectionViewCell {
 
     // MARK: - Methods
 
-    func configure(image: UIImage) {
+    func configure(image: UIImage?, status: BoardStatus) {
         thumbnailImageView.image = image
+
+        switch status {
+        case .complete:
+            spinner.stopAnimating()
+        default:
+            spinner.startAnimating()
+        }
     }
 
     private func setUI() {
@@ -46,13 +61,17 @@ final class ThumbnailCollectionViewCell: UICollectionViewCell {
     }
 
     private func setConstraints() {
-        contentView.addSubview(thumbnailImageView)
-        thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubviews(thumbnailImageView, spinner)
+        contentView.subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+
         NSLayoutConstraint.activate([
             thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            thumbnailImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            thumbnailImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            spinner.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
     }
 

--- a/iOS/Layover/Layover/Scenes/Profile/Views/ThumbnailCollectionViewCell.swift
+++ b/iOS/Layover/Layover/Scenes/Profile/Views/ThumbnailCollectionViewCell.swift
@@ -20,8 +20,8 @@ final class ThumbnailCollectionViewCell: UICollectionViewCell {
     }()
 
     private let spinner: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .large)
-        indicator.color = .primaryPurple
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.backgroundColor = .clear
         indicator.hidesWhenStopped = true
         indicator.stopAnimating()
         return indicator
@@ -49,13 +49,15 @@ final class ThumbnailCollectionViewCell: UICollectionViewCell {
         switch status {
         case .complete:
             spinner.stopAnimating()
+            thumbnailImageView.alpha = 1.0
         default:
             spinner.startAnimating()
+            thumbnailImageView.alpha = 0.5
         }
     }
 
     private func setUI() {
-        backgroundColor = .primaryPurple
+        backgroundColor = .darkGrey
         layer.cornerRadius = 10
         clipsToBounds = true
     }

--- a/iOS/Layover/LayoverTests/Mocks/MockDatas/PostList.json
+++ b/iOS/Layover/LayoverTests/Mocks/MockDatas/PostList.json
@@ -16,7 +16,8 @@
                 "longitude" : 37.0532156213,
                 "latitude" : 127.060123123,
                 "title" : "최강 아이돌",
-                "content" : "게시글 설명"
+                "content" : "게시글 설명",
+                "status": "COMPLETE"
             },
             "tag" : ["아이브", "yujin"]
         }

--- a/iOS/Layover/LayoverTests/Mocks/MockDatas/PostListMore.json
+++ b/iOS/Layover/LayoverTests/Mocks/MockDatas/PostListMore.json
@@ -16,7 +16,8 @@
                 "longitude" : 35.001828282,
                 "latitude" : 100.060123123,
                 "title" : "아이브의 멤버",
-                "content" : "게시글 설명설명설명"
+                "content" : "게시글 설명설명설명",
+                "status": "COMPLETE"
             },
             "tag" : ["Ive", "wonyoung"]
         }

--- a/iOS/Layover/LayoverTests/Scenes/Home/HomeInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Home/HomeInteractorTests.swift
@@ -78,6 +78,7 @@ final class HomeInteractorTests: XCTestCase {
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].board.longitude, Seeds.Posts.post1.board.longitude, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].board.thumbnailImageURL, Seeds.Posts.post1.board.thumbnailImageURL, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].board.videoURL, Seeds.Posts.post1.board.videoURL, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
+        XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].board.status, Seeds.Posts.post1.board.status, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].member.username, Seeds.Posts.post1.member.username, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].member.introduce, Seeds.Posts.post1.member.introduce, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")
         XCTAssertEqual(spy.presentPostsReceivedResponse.posts[0].member.profileImageURL, Seeds.Posts.post1.member.profileImageURL, "fetchPost()가 presenter에게 올바른 데이터를 저장했다.")

--- a/iOS/Layover/LayoverTests/Scenes/Home/HomeWorkerTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Home/HomeWorkerTests.swift
@@ -68,6 +68,7 @@ final class HomeWorkerTests: XCTestCase {
         XCTAssertEqual(result![0].board.videoURL, Seeds.Posts.post1.board.videoURL)
         XCTAssertEqual(result![0].board.latitude, Seeds.Posts.post1.board.latitude)
         XCTAssertEqual(result![0].board.longitude, Seeds.Posts.post1.board.longitude)
+        XCTAssertEqual(result![0].board.status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(result![0].member.identifier, Seeds.Posts.post1.member.identifier)
         XCTAssertEqual(result![0].member.username, Seeds.Posts.post1.member.username)
         XCTAssertEqual(result![0].member.introduce, Seeds.Posts.post1.member.introduce)

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfileInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfileInteractorTests.swift
@@ -76,10 +76,10 @@ final class ProfileInteractorTests: XCTestCase {
 
         // assert
         XCTAssertTrue(presentationLogicSpy.presentProfileCalled, "fetchProfile을 호출해서 presentProfile을 호출했다")
-        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts.count, 1)
-        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].thumbnailImageData, Seeds.sampleImageData)
-        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].status, Seeds.Posts.post1.board.status)
+        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.displayedPosts.count, 1)
+        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.displayedPosts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.displayedPosts[0].thumbnailImageData, Seeds.sampleImageData)
+        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.displayedPosts[0].status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.username, Seeds.Members.getMember1.username)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.introduce, Seeds.Members.getMember1.introduce)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.profileImageData, Seeds.sampleImageData, "presentProfileResponse에는 fetchProfile의 결과가 올바르게 담겼다.")
@@ -95,10 +95,10 @@ final class ProfileInteractorTests: XCTestCase {
 
         // assert
         XCTAssertTrue(presentationLogicSpy.presentMorePostsCalled, "fetchMorePosts을 호출하여 presentMorePosts을 호출했다")
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts.count, 1, "fetchMorePosts를 호출하여 올바른 데이터를 전달했다")
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].thumbnailImageData, Seeds.sampleImageData)
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].status, Seeds.Posts.post1.board.status, "fetchMorePosts를 실행하여 presenter에 올바른 데이터를 전달했다")
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.displayedPosts.count, 1, "fetchMorePosts를 호출하여 올바른 데이터를 전달했다")
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.displayedPosts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.displayedPosts[0].thumbnailImageData, Seeds.sampleImageData)
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.displayedPosts[0].status, Seeds.Posts.post1.board.status, "fetchMorePosts를 실행하여 presenter에 올바른 데이터를 전달했다")
     }
 
     func test_showPostDetail을_호출하면_자신의_playbackStartIndex에_값을_저장하고_presenter의_presentPostDetail을_호출한다() async {

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfileInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfileInteractorTests.swift
@@ -79,6 +79,7 @@ final class ProfileInteractorTests: XCTestCase {
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts.count, 1)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].id, Seeds.Posts.post1.board.identifier)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].thumbnailImageData, Seeds.sampleImageData)
+        XCTAssertEqual(presentationLogicSpy.presentProfileResponse.posts[0].status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.username, Seeds.Members.getMember1.username)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.introduce, Seeds.Members.getMember1.introduce)
         XCTAssertEqual(presentationLogicSpy.presentProfileResponse.userProfile.profileImageData, Seeds.sampleImageData, "presentProfileResponse에는 fetchProfile의 결과가 올바르게 담겼다.")
@@ -93,10 +94,11 @@ final class ProfileInteractorTests: XCTestCase {
         _ = await sut.fetchMorePosts(with: Models.FetchMorePosts.Request()).value
 
         // assert
-        XCTAssertTrue(presentationLogicSpy.presentMorePostsCalled, "fetchMorePosts을 호출해서 presentMorePosts을 호출했다")
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts.count, 1, "presentMorePostsResponse에는 fetchPosts의 결과가 담겼다")
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].id, Seeds.Posts.post1.board.identifier, "presentMorePostsResponse에는 fetchPosts의 결과가 담겼다")
-        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].thumbnailImageData, Seeds.sampleImageData, "presentMorePostsResponse에는 fetchPosts의 결과가 담겼다")
+        XCTAssertTrue(presentationLogicSpy.presentMorePostsCalled, "fetchMorePosts을 호출하여 presentMorePosts을 호출했다")
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts.count, 1, "fetchMorePosts를 호출하여 올바른 데이터를 전달했다")
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].thumbnailImageData, Seeds.sampleImageData)
+        XCTAssertEqual(presentationLogicSpy.presentMorePostsResponse.posts[0].status, Seeds.Posts.post1.board.status, "fetchMorePosts를 실행하여 presenter에 올바른 데이터를 전달했다")
     }
 
     func test_showPostDetail을_호출하면_자신의_playbackStartIndex에_값을_저장하고_presenter의_presentPostDetail을_호출한다() async {

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
@@ -70,7 +70,7 @@ final class ProfilePresenterTests: XCTestCase {
         let response = Models.FetchProfile.Response(userProfile: ProfileModels.Profile(username: Seeds.Members.getMember1.username,
                                                                                        introduce: Seeds.Members.getMember1.introduce,
                                                                                        profileImageData: Seeds.sampleImageData),
-                                                    posts: [.init(id: Seeds.Posts.post1.board.identifier,
+                                                    displayedPosts: [.init(id: Seeds.Posts.post1.board.identifier,
                                                                   thumbnailImageData: Seeds.sampleImageData, 
                                                                   status: Seeds.Posts.post1.board.status)])
         // act
@@ -93,7 +93,7 @@ final class ProfilePresenterTests: XCTestCase {
         sut.viewController = spy
 
         // act
-        let response = Models.FetchMorePosts.Response(posts: [.init(id: Seeds.Posts.post1.board.identifier,
+        let response = Models.FetchMorePosts.Response(displayedPosts: [.init(id: Seeds.Posts.post1.board.identifier,
                                                                     thumbnailImageData: Seeds.sampleImageData,
                                                                     status: Seeds.Posts.post1.board.status)])
         sut.presentMorePosts(with: response)

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
@@ -81,10 +81,10 @@ final class ProfilePresenterTests: XCTestCase {
         XCTAssertEqual(spy.displayProfileViewModel.userProfile.username, Seeds.Members.getMember1.username)
         XCTAssertEqual(spy.displayProfileViewModel.userProfile.introduce, Seeds.Members.getMember1.introduce)
         XCTAssertEqual(spy.displayProfileViewModel.userProfile.profileImageData, Seeds.sampleImageData)
-        XCTAssertEqual(spy.displayProfileViewModel.posts.count, 1)
-        XCTAssertEqual(spy.displayProfileViewModel.posts[0].id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(spy.displayProfileViewModel.posts[0].status, Seeds.Posts.post1.board.status)
-        XCTAssertEqual(spy.displayProfileViewModel.posts[0].thumbnailImageData, Seeds.sampleImageData, "presentprofile은 올바른 데이터를 뷰에 전달했다")
+        XCTAssertEqual(spy.displayProfileViewModel.displayedPosts.count, 1)
+        XCTAssertEqual(spy.displayProfileViewModel.displayedPosts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(spy.displayProfileViewModel.displayedPosts[0].status, Seeds.Posts.post1.board.status)
+        XCTAssertEqual(spy.displayProfileViewModel.displayedPosts[0].thumbnailImageData, Seeds.sampleImageData, "presentprofile은 올바른 데이터를 뷰에 전달했다")
     }
 
     func test_presentMorePosts을_호출하면_displayMorePosts를_호출하고_올바른_데이터를_전달한다() {
@@ -100,10 +100,10 @@ final class ProfilePresenterTests: XCTestCase {
 
         // assert
         XCTAssertTrue(spy.displayMorePostsCalled, "presentMorePosts은 displayMorePosts을 호출했다")
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts.count, 1)
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].status, Seeds.Posts.post1.board.status)
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].thumbnailImageData, Seeds.sampleImageData, "presentMorePosts은 올바른 데이터를 뷰에 전달했다")
+        XCTAssertEqual(spy.displayMorePostsViewModel.displayedPosts.count, 1)
+        XCTAssertEqual(spy.displayMorePostsViewModel.displayedPosts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(spy.displayMorePostsViewModel.displayedPosts[0].status, Seeds.Posts.post1.board.status)
+        XCTAssertEqual(spy.displayMorePostsViewModel.displayedPosts[0].thumbnailImageData, Seeds.sampleImageData, "presentMorePosts은 올바른 데이터를 뷰에 전달했다")
     }
 
     func test_presentPostDetail을_호출하면_routeToPostDetail을_호출한다() {

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfilePresenterTests.swift
@@ -71,8 +71,8 @@ final class ProfilePresenterTests: XCTestCase {
                                                                                        introduce: Seeds.Members.getMember1.introduce,
                                                                                        profileImageData: Seeds.sampleImageData),
                                                     posts: [.init(id: Seeds.Posts.post1.board.identifier,
-
-                                                                  thumbnailImageData: Seeds.sampleImageData)])
+                                                                  thumbnailImageData: Seeds.sampleImageData, 
+                                                                  status: Seeds.Posts.post1.board.status)])
         // act
         sut.presentProfile(with: response)
 
@@ -82,8 +82,9 @@ final class ProfilePresenterTests: XCTestCase {
         XCTAssertEqual(spy.displayProfileViewModel.userProfile.introduce, Seeds.Members.getMember1.introduce)
         XCTAssertEqual(spy.displayProfileViewModel.userProfile.profileImageData, Seeds.sampleImageData)
         XCTAssertEqual(spy.displayProfileViewModel.posts.count, 1)
-        XCTAssertEqual(spy.displayProfileViewModel.posts.first?.id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(spy.displayProfileViewModel.posts.first?.thumbnailImageData, Seeds.sampleImageData, "presentprofile은 올바른 데이터를 뷰에 전달했다")
+        XCTAssertEqual(spy.displayProfileViewModel.posts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(spy.displayProfileViewModel.posts[0].status, Seeds.Posts.post1.board.status)
+        XCTAssertEqual(spy.displayProfileViewModel.posts[0].thumbnailImageData, Seeds.sampleImageData, "presentprofile은 올바른 데이터를 뷰에 전달했다")
     }
 
     func test_presentMorePosts을_호출하면_displayMorePosts를_호출하고_올바른_데이터를_전달한다() {
@@ -93,14 +94,16 @@ final class ProfilePresenterTests: XCTestCase {
 
         // act
         let response = Models.FetchMorePosts.Response(posts: [.init(id: Seeds.Posts.post1.board.identifier,
-                                                                     thumbnailImageData: Seeds.sampleImageData)])
+                                                                    thumbnailImageData: Seeds.sampleImageData,
+                                                                    status: Seeds.Posts.post1.board.status)])
         sut.presentMorePosts(with: response)
 
         // assert
         XCTAssertTrue(spy.displayMorePostsCalled, "presentMorePosts은 displayMorePosts을 호출했다")
         XCTAssertEqual(spy.displayMorePostsViewModel.posts.count, 1)
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts.first?.id, Seeds.Posts.post1.board.identifier)
-        XCTAssertEqual(spy.displayMorePostsViewModel.posts.first?.thumbnailImageData, Seeds.sampleImageData, "presentMorePosts은 올바른 데이터를 뷰에 전달했다")
+        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].id, Seeds.Posts.post1.board.identifier)
+        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].status, Seeds.Posts.post1.board.status)
+        XCTAssertEqual(spy.displayMorePostsViewModel.posts[0].thumbnailImageData, Seeds.sampleImageData, "presentMorePosts은 올바른 데이터를 뷰에 전달했다")
     }
 
     func test_presentPostDetail을_호출하면_routeToPostDetail을_호출한다() {

--- a/iOS/Layover/LayoverTests/Scenes/Profile/ProfileViewControllerTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/Profile/ProfileViewControllerTests.swift
@@ -75,7 +75,7 @@ final class ProfileViewControllerTests: XCTestCase {
         XCTAssertTrue(spy.fetchProfileCalled, "viewWillAppear가 호출되어 fetchProfile이 호출했다")
     }
 
-    func test_스크롤이_바닥에_닿아_scrollViewBeginDecelerating이_호출되면_fetchPosts가_호출된다() {
+    func test_스크롤이_바닥에_닿아_scrollViewBeginDecelerating이_호출되면_fetchMorePosts가_호출된다() {
         // arrange
         let spy = ProfileBusinessLogicSpy()
         sut.interactor = spy
@@ -91,7 +91,7 @@ final class ProfileViewControllerTests: XCTestCase {
         XCTAssertTrue(spy.fetchMorePostsCalled, "스크롤이 바닥에 닿아 scrollViewBeginDecelerating이 호출되어 fetchPosts가 호출했다")
     }
 
-    func test_스크롤이_바닥에_닿지_않고_scrollViewBeginDecelerating이_호출되면_fetchPosts가_호출된다() {
+    func test_스크롤이_바닥에_닿지_않고_scrollViewBeginDecelerating이_호출되면_fetchMorePosts가_호출된다() {
         // arrange
         let spy = ProfileBusinessLogicSpy()
         sut.interactor = spy
@@ -105,5 +105,21 @@ final class ProfileViewControllerTests: XCTestCase {
 
         // assert
         XCTAssertFalse(spy.fetchMorePostsCalled, "스크롤이 바닥에 닿지 않고 scrollViewBeginDecelerating이 호출되어 fetchPosts가 호출되지 않았다")
+    }
+
+    func test_스크롤을_아래로_당겨서_scrollViewBeginDecelerating이_호출되면_fetchMorePosts가_호출되지_않았다() {
+        // arrange
+        let spy = ProfileBusinessLogicSpy()
+        sut.interactor = spy
+        let scrollView = UIScrollView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        scrollView.contentSize.height = 50
+        scrollView.contentOffset.y = -100
+
+
+        // act
+        sut.scrollViewWillBeginDecelerating(scrollView)
+
+        // assert
+        XCTAssertFalse(spy.fetchMorePostsCalled, "스크롤이 아래로 당겨져서 scrollViewBeginDecelerating이 호출되어 fetchPosts가 호출되었다")
     }
 }

--- a/iOS/Layover/LayoverTests/Scenes/TagPlayList/TagPlayListInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/TagPlayList/TagPlayListInteractorTests.swift
@@ -112,6 +112,7 @@ final class TagPlayListInteractorTests: XCTestCase {
         XCTAssertEqual(sut.posts[0].board.longitude, Seeds.Posts.post1.board.longitude)
         XCTAssertEqual(sut.posts[0].board.videoURL, Seeds.Posts.post1.board.videoURL)
         XCTAssertEqual(sut.posts[0].board.thumbnailImageURL, Seeds.Posts.post1.board.thumbnailImageURL)
+        XCTAssertEqual(sut.posts[0].board.status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(sut.posts[0].member.identifier, Seeds.Posts.post1.member.identifier)
         XCTAssertEqual(sut.posts[0].member.username, Seeds.Posts.post1.member.username)
         XCTAssertEqual(sut.posts[0].member.introduce, Seeds.Posts.post1.member.introduce)
@@ -141,6 +142,7 @@ final class TagPlayListInteractorTests: XCTestCase {
             && $0.board.videoURL == Seeds.Posts.post2.board.videoURL
             && $0.board.latitude == Seeds.Posts.post2.board.latitude
             && $0.board.longitude == Seeds.Posts.post2.board.longitude
+            && $0.board.status == Seeds.Posts.post2.board.status
             && $0.member.identifier == Seeds.Posts.post2.member.identifier
             && $0.member.username == Seeds.Posts.post2.member.username
             && $0.member.introduce == Seeds.Posts.post2.member.introduce
@@ -157,6 +159,7 @@ final class TagPlayListInteractorTests: XCTestCase {
         XCTAssertEqual(sut.posts[0].board.longitude, Seeds.Posts.post1.board.longitude)
         XCTAssertEqual(sut.posts[0].board.videoURL, Seeds.Posts.post1.board.videoURL)
         XCTAssertEqual(sut.posts[0].board.thumbnailImageURL, Seeds.Posts.post1.board.thumbnailImageURL)
+        XCTAssertEqual(sut.posts[0].board.status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(sut.posts[0].member.identifier, Seeds.Posts.post1.member.identifier)
         XCTAssertEqual(sut.posts[0].member.username, Seeds.Posts.post1.member.username)
         XCTAssertEqual(sut.posts[0].member.introduce, Seeds.Posts.post1.member.introduce)
@@ -219,6 +222,7 @@ final class TagPlayListInteractorTests: XCTestCase {
             && $0.board.videoURL == Seeds.Posts.post1.board.videoURL
             && $0.board.latitude == Seeds.Posts.post1.board.latitude
             && $0.board.longitude == Seeds.Posts.post1.board.longitude
+            && $0.board.status == Seeds.Posts.post1.board.status
             && $0.member.identifier == Seeds.Posts.post1.member.identifier
             && $0.member.username == Seeds.Posts.post1.member.username
             && $0.member.introduce == Seeds.Posts.post1.member.introduce

--- a/iOS/Layover/LayoverTests/Scenes/TagPlayList/TagPlayListWorkerTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/TagPlayList/TagPlayListWorkerTests.swift
@@ -66,6 +66,7 @@ final class TagPlayListWorkerTests: XCTestCase {
         XCTAssertEqual(result![0].board.videoURL, Seeds.Posts.post1.board.videoURL)
         XCTAssertEqual(result![0].board.latitude, Seeds.Posts.post1.board.latitude)
         XCTAssertEqual(result![0].board.longitude, Seeds.Posts.post1.board.longitude)
+        XCTAssertEqual(result![0].board.status, Seeds.Posts.post1.board.status)
         XCTAssertEqual(result![0].member.identifier, Seeds.Posts.post1.member.identifier)
         XCTAssertEqual(result![0].member.username, Seeds.Posts.post1.member.username)
         XCTAssertEqual(result![0].member.profileImageURL, Seeds.Posts.post1.member.profileImageURL)

--- a/iOS/Layover/LayoverTests/Seeds.swift
+++ b/iOS/Layover/LayoverTests/Seeds.swift
@@ -24,7 +24,9 @@ class Seeds {
                                              thumbnailImageURL: URL(string: "https://think-note.com/wp-content/uploads/2023/07/eta_3.jpg")!,
                                              videoURL: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8")!,
                                              latitude: 127.060123123,
-                                             longitude: 37.0532156213),
+                                             longitude: 37.0532156213,
+                                             status: .complete
+                                            ),
                                 tag: ["아이브", "yujin"])
 
         // PostListMore.json에 정의된 데이터
@@ -38,7 +40,9 @@ class Seeds {
                                              thumbnailImageURL: URL(string: "https://img.etoday.co.kr/pto_db/2022/11/600/20221108175829_1816470_1200_1800.jpg")!,
                                              videoURL: URL(string: "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8")!,
                                              latitude: 100.060123123,
-                                             longitude: 35.001828282),
+                                             longitude: 35.001828282,
+                                             status: .complete
+                                            ),
                                 tag: ["Ive", "wonyoung"])
         
         static let thumbnailImageNilPost = Post(member: Member(identifier: 1,
@@ -51,7 +55,9 @@ class Seeds {
                                       thumbnailImageURL: nil,
                                       videoURL: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8")!,
                                       latitude: 127.060123123,
-                                      longitude: 37.0532156213),
+                                      longitude: 37.0532156213,
+                                      status: .complete
+                                     ),
                          tag: ["아이브", "yujin"])
 
         static let videoURLNilPost = Post(member: Member(identifier: 1,
@@ -64,7 +70,9 @@ class Seeds {
                                       thumbnailImageURL: nil,
                                       videoURL: nil,
                                       latitude: 127.060123123,
-                                      longitude: 37.0532156213),
+                                      longitude: 37.0532156213,
+                                      status: .complete
+                                     ),
                          tag: ["아이브", "yujin"])
 
     }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 프로필 뷰에서 업로드 상태의 영상 로딩 처리
- 프로필 뷰 Pull To Refresh 구현
- 프로필 편집 뷰에서 이미지 편집을 안했음에도 기본 이미지로 변경되는 버그 수정
- 프로필 뷰에서 DisplayModel의 Hashable문제로 DiffableDataSource 크래시 나는 버그 수정
- 변경된 BoardDTO 맞추어 테스트 코드 수정

업로드 처리 중인 셀은 터치 시, 토스트 메시지를 띄우도록 했습니다!

##### 📸 ScreenShot
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-12 at 23 54 28](https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/00022d7e-10be-4c9c-9ee7-95b84d950d97)


#### Linked Issue
close #299 
