### PR TITLE
chore: 태그별, 프로필 영상 최신영상부터 내려줌

### DIFF
--- a/BE/layover/src/board/board.entity.ts
+++ b/BE/layover/src/board/board.entity.ts
@@ -35,6 +35,13 @@ export class Board {
   @Column({ nullable: false })
   status: string;
 
+  @Column({
+    nullable: false,
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  date_created: Date;
+
   constructor(
     member: Member,
     title: string,

--- a/BE/layover/src/board/board.repository.ts
+++ b/BE/layover/src/board/board.repository.ts
@@ -48,6 +48,7 @@ export class BoardRepository {
       .leftJoinAndSelect('board.tags', 'tag')
       .where('tag.tagname = :tag', { tag })
       .andWhere("board.status = 'COMPLETE'")
+      .orderBy('board.date_created', 'DESC')
       .skip(offset)
       .take(itemsPerPage)
       .getMany();
@@ -69,6 +70,7 @@ export class BoardRepository {
       .leftJoinAndSelect('board.tags', 'tag')
       .where('member.id = :id', { id })
       .andWhere("board.status IN ('COMPLETE', 'WAITING', 'RUNNING')")
+      .orderBy('board.date_created', 'DESC')
       .skip(offset)
       .take(itemsPerPage)
       .getMany();


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- 생성필드를 추가하고, 태그와 프로필은 최근 생성된 파일부터 보여주도록 설정

##### 📸 ScreenShot
![image](https://github.com/boostcampwm2023/iOS09-Layover/assets/75191916/4ab95a71-7c8a-4f15-ae93-70c11264da4f)

