### PR TITLE
test: 빠진 assert문 수정

### DIFF
--- a/iOS/Layover/LayoverTests/Scenes/SignUp/SignUpInteractorTests.swift
+++ b/iOS/Layover/LayoverTests/Scenes/SignUp/SignUpInteractorTests.swift
@@ -137,6 +137,7 @@ final class SignUpInteractorTests: XCTestCase {
         await sut.signUp(with: Models.SignUp.Request(nickname: "안유진"))
 
         // assert
+        XCTAssertTrue(signUpWorkerSpy.signUpWithKakaoCalled)
         XCTAssertTrue(presenterSpy.presentSignUpSuccessDidCalled)
     }
 
@@ -154,6 +155,7 @@ final class SignUpInteractorTests: XCTestCase {
         await sut.signUp(with: Models.SignUp.Request(nickname: "안유진"))
 
         // assert
+        XCTAssertTrue(signUpWorkerSpy.signUpWithAppleCalled)
         XCTAssertTrue(presenterSpy.presentSignUpSuccessDidCalled)
     }
 }


### PR DESCRIPTION
signUpInteractorTests에서 빠진 assert 문이 있어서 추가했습니다.