### PR TITLE
feat: prefetching을 통한 성능개선 시도

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		8321A2FF2B1E428C000A12AF /* ReportDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8321A2FE2B1E428C000A12AF /* ReportDTO.swift */; };
 		8321A3012B1F1EC5000A12AF /* MockReportWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8321A3002B1F1EC5000A12AF /* MockReportWorker.swift */; };
 		8321A3032B1F2041000A12AF /* ReportPlaybackVideo.json in Resources */ = {isa = PBXBuildFile; fileRef = 8321A3022B1F2041000A12AF /* ReportPlaybackVideo.json */; };
+		833CC1242B5950920027D96F /* Prefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833CC1232B5950920027D96F /* Prefetcher.swift */; };
 		834B7BD52B14F888002BD176 /* MockSignUpWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834B7BD42B14F888002BD176 /* MockSignUpWorker.swift */; };
 		835783C32B14A41600E7D304 /* MockLoginWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835783C22B14A41600E7D304 /* MockLoginWorker.swift */; };
 		835783C62B14A5C800E7D304 /* LoginData.json in Resources */ = {isa = PBXBuildFile; fileRef = 835783C52B14A5C800E7D304 /* LoginData.json */; };
@@ -397,6 +398,7 @@
 		8321A2FE2B1E428C000A12AF /* ReportDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDTO.swift; sourceTree = "<group>"; };
 		8321A3002B1F1EC5000A12AF /* MockReportWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReportWorker.swift; sourceTree = "<group>"; };
 		8321A3022B1F2041000A12AF /* ReportPlaybackVideo.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ReportPlaybackVideo.json; sourceTree = "<group>"; };
+		833CC1232B5950920027D96F /* Prefetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prefetcher.swift; sourceTree = "<group>"; };
 		834B7BD42B14F888002BD176 /* MockSignUpWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignUpWorker.swift; sourceTree = "<group>"; };
 		835783C22B14A41600E7D304 /* MockLoginWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginWorker.swift; sourceTree = "<group>"; };
 		835783C52B14A5C800E7D304 /* LoginData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LoginData.json; sourceTree = "<group>"; };
@@ -881,6 +883,14 @@
 			path = Report;
 			sourceTree = "<group>";
 		};
+		833CC1222B59507E0027D96F /* Prefetcher */ = {
+			isa = PBXGroup;
+			children = (
+				833CC1232B5950920027D96F /* Prefetcher.swift */,
+			);
+			path = Prefetcher;
+			sourceTree = "<group>";
+		};
 		835A61962B0680FC002F22A5 /* Playback */ = {
 			isa = PBXGroup;
 			children = (
@@ -1039,6 +1049,7 @@
 		FC68E2992B02320F001AABFF /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				833CC1222B59507E0027D96F /* Prefetcher */,
 				FCE52FF62B0FCADB002CDB75 /* Mock */,
 				19AACFC82B0F7C200088143E /* DTOs */,
 				19C7AFCF2B02441C003B35F2 /* Common */,
@@ -1498,6 +1509,7 @@
 				FC0E80272B1A0BBB00EF56D6 /* UploadPostModels.swift in Sources */,
 				194552312B04DA1A00299768 /* LOCircleButton.swift in Sources */,
 				194552262B0478B400299768 /* HomeInteractor.swift in Sources */,
+				833CC1242B5950920027D96F /* Prefetcher.swift in Sources */,
 				FC930E772B0CD75C00AA48E3 /* ProfileRouter.swift in Sources */,
 				FC0E80302B1A15D600EF56D6 /* LOImageLabel.swift in Sources */,
 				FC5BE11F2B148D160036366D /* EditProfileModels.swift in Sources */,

--- a/iOS/Layover/Layover/Network/Prefetcher/Prefetcher.swift
+++ b/iOS/Layover/Layover/Network/Prefetcher/Prefetcher.swift
@@ -56,7 +56,6 @@ actor Prefetcher: PrefetchProtocol {
 
         do {
             let fetchedData: Data = try await fetchTask.value
-            print("chopmojji: \(fetchedData.count)")
             imageCache.setObject(fetchedData as NSData, forKey: key as NSURL)
             fetchingImageTasks[key] = nil
             return fetchedData

--- a/iOS/Layover/Layover/Network/Prefetcher/Prefetcher.swift
+++ b/iOS/Layover/Layover/Network/Prefetcher/Prefetcher.swift
@@ -1,0 +1,113 @@
+//
+//  Prefetcher.swift
+//  Layover
+//
+//  Created by 황지웅 on 1/18/24.
+//  Copyright © 2024 CodeBomber. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+import OSLog
+
+protocol PrefetchProtocol {
+    func prefetchImage(for key: URL) async -> Data?
+    func prefetchLoaction(latitude: Double, longitude: Double) async -> String?
+    func cancelPrefetchImage(for key: URL) async
+    func cancelPrefetchLocation(latitude: Double, longitude: Double) async
+}
+
+actor Prefetcher: PrefetchProtocol {
+    private let imageCache: NSCache<NSURL, NSData> = NSCache()
+    private let locationCache: NSCache<NSString, NSString> = NSCache()
+
+    private var fetchingImageTasks: [URL: Task<Data, Error>] = [:]
+    private var fetchingLocationTasks: [String: Task<String?, Error>] = [:]
+
+    private let provider: ProviderType = Provider()
+
+    func prefetchImage(for key: URL) async -> Data? {
+        if let cachedData = imageCache.object(forKey: key as NSURL) as? Data {
+            return cachedData
+        }
+
+        if let prefetchingData = fetchingImageTasks[key] {
+            do {
+                return try await prefetchingData.value
+            } catch {
+                os_log(.error, log: .data, "%@", error.localizedDescription)
+                return nil
+            }
+        }
+        
+        let fetchTask: Task<Data, Error> = download(key)
+        fetchingImageTasks[key] = fetchTask
+
+        do {
+            let fetchedData: Data = try await fetchTask.value
+            imageCache.setObject(fetchedData as NSData, forKey: key as NSURL)
+            fetchingImageTasks[key] = nil
+            return fetchedData
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
+    }
+
+    func prefetchLoaction(latitude: Double, longitude: Double) async -> String? {
+        let cacheKey = "\(latitude)-\(longitude)"
+
+        if let cachedData = locationCache.object(forKey: cacheKey as NSString) as? String {
+            return cachedData
+        }
+
+        if let prefetchingData = fetchingLocationTasks[cacheKey] {
+            do {
+                return try await prefetchingData.value
+            } catch {
+                os_log(.error, log: .data, "%@", error.localizedDescription)
+                return nil
+            }
+        }
+
+        let fetchTask: Task<String?, Error> = loadLocationInfo(latitude: latitude, longitude: longitude)
+        fetchingLocationTasks[cacheKey] = fetchTask
+
+        do {
+            guard let fetchedData: String = try await fetchTask.value else { return nil }
+            locationCache.setObject(fetchedData as NSString, forKey: cacheKey as NSString)
+            return fetchedData
+        } catch {
+            os_log(.error, log: .data, "%@", error.localizedDescription)
+            return nil
+        }
+    }
+
+    func cancelPrefetchImage(for key: URL) async {
+        fetchingImageTasks[key]?.cancel()
+        fetchingImageTasks[key] = nil
+    }
+
+    func cancelPrefetchLocation(latitude: Double, longitude: Double) async {
+        let key = "\(latitude)-\(longitude)"
+        fetchingLocationTasks[key]?.cancel()
+        fetchingLocationTasks[key] = nil
+    }
+
+    private func download(_ url: URL) -> Task<Data, Error> {
+        return Task {
+            try await provider.request(url: url)
+        }
+    }
+
+    private func loadLocationInfo(latitude: Double, longitude: Double) -> Task<String?, Error> {
+         return Task {
+            let findLocation: CLLocation = CLLocation(latitude: latitude, longitude: longitude)
+            let geoCoder: CLGeocoder = CLGeocoder()
+            let localeIdentifier = Locale.preferredLanguages.first != nil ? Locale.preferredLanguages[0] : Locale.current.identifier
+            let locale = Locale(identifier: localeIdentifier)
+            let place = try await geoCoder.reverseGeocodeLocation(findLocation, preferredLocale: locale)
+            return place.last?.administrativeArea
+        }
+    }
+}

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackViewController.swift
@@ -96,6 +96,7 @@ final class PlaybackViewController: BaseViewController {
         }
         interactor?.configurePlaybackCell()
         playbackCollectionView.delegate = self
+        playbackCollectionView.prefetchDataSource = self
         playbackCollectionView.contentInsetAdjustmentBehavior = .never
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
@@ -420,6 +421,24 @@ extension PlaybackViewController: PlaybackViewControllerDelegate {
     func moveToTagPlay(selectedTag: String) {
         let request: Models.MoveToRelativeView.Request = Models.MoveToRelativeView.Request(indexPathRow: nil, selectedTag: selectedTag)
         interactor?.moveToTagPlay(with: request)
+    }
+}
+
+extension PlaybackViewController: UICollectionViewDataSourcePrefetching {
+    func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
+        for indexPath in indexPaths {
+            Task {
+                await interactor?.prefetchLoadProfileImageAndLocation(with: Models.SetInitialPlaybackCell.Request(indexPathRow: indexPath.row))
+            }
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cancelPrefetchingForItemsAt indexPaths: [IndexPath]) {
+        for indexPath in indexPaths {
+            Task {
+                await interactor?.cancelPrefetchProfileImageAndLocation(with: Models.SetInitialPlaybackCell.Request(indexPathRow: indexPath.row))
+            }
+        }
     }
 }
 //#Preview {

--- a/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
+++ b/iOS/Layover/Layover/Workers/Mocks/MockPlaybackWorker.swift
@@ -187,4 +187,21 @@ final class MockPlaybackWorker: PlaybackWorkerProtocol {
         return currentCellMemberID == authManager.memberID
     }
 
+    // TODO: Test 짜보기
+    func prefetchProfileImage(with url: URL?) async -> Data? {
+        return nil
+    }
+
+    func prefetchLocation(latitude: Double, longitude: Double) async -> String? {
+        return nil
+    }
+
+    func cancelPrefetchProfileImage(with url: URL?) async {
+        //
+    }
+
+    func cancelPrefetchLocation(latitude: Double, longitude: Double) async {
+        //
+    }
+
 }

--- a/iOS/Layover/LayoverTests/Mocks/Workers/MockPlaybackWorker.swift
+++ b/iOS/Layover/LayoverTests/Mocks/Workers/MockPlaybackWorker.swift
@@ -169,4 +169,20 @@ final class MockPlaybackWorker: PlaybackWorkerProtocol {
         return currentCellMemberID == authManager.memberID
     }
 
+    // TODO: Test 짜보기
+    func prefetchProfileImage(with url: URL?) async -> Data? {
+        return nil
+    }
+
+    func prefetchLocation(latitude: Double, longitude: Double) async -> String? {
+        return nil
+    }
+
+    func cancelPrefetchProfileImage(with url: URL?) async {
+        //
+    }
+
+    func cancelPrefetchLocation(latitude: Double, longitude: Double) async {
+        //
+    }
 }


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
Prefetcher구현
재생화면에서 collectionView prefetch DataSource 시점에 prefetch 동작
prefetch해서 가져오는게 현재 프로필 이미지, 위치 정보인데 프로필 이미지의 경우 많아봤자 116250 bytes? 정도 밖에 안되는 관계로...
그렇게 큰 이득을 가져오지는 않는 것 같음.
그러나 기존엔 재생화면 빠르게 스크롤 하면 프로필이 조금 늦게 뜨는 경우가 있었는데, prefetch 적용 후 그런 모습은 보이지 않음(cache의 영향도 분명 있음)

### 고민
prefetcher의 경우 provider가 필요한데 이를 어디서 주입해주는게 좋을지 고민
worker에서 lazy var해서 넣는게 나을지 아니면 그냥 prefetcher가 provider들고 있는게 나을지
지금은 후자의 경우

#### Linked Issue
close #348 
