### PR TITLE
feat: HLS 캐싱 적용

### DIFF
--- a/iOS/Layover/Layover.xcodeproj/project.pbxproj
+++ b/iOS/Layover/Layover.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		19AE482A2B2A127E00DD4612 /* HLSAssetResourceLoaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AE48292B2A127E00DD4612 /* HLSAssetResourceLoaderDelegate.swift */; };
 		19AE482C2B2A1A8B00DD4612 /* HLSSliceResourceLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AE482B2B2A1A8B00DD4612 /* HLSSliceResourceLoader.swift */; };
 		19AE482E2B2A24C700DD4612 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AE482D2B2A24C700DD4612 /* URL+.swift */; };
+		19AF2A062B5D06B9008C3620 /* HLSCachingServer in Frameworks */ = {isa = PBXBuildFile; productRef = 19AF2A052B5D06B9008C3620 /* HLSCachingServer */; };
 		19B665D92B4EEDDD0083E63C /* SignUpWorkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B665D52B4EEDDD0083E63C /* SignUpWorkerTests.swift */; };
 		19B665DA2B4EEDDD0083E63C /* SignUpInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B665D62B4EEDDD0083E63C /* SignUpInteractorTests.swift */; };
 		19B665DB2B4EEDDD0083E63C /* SignUpPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B665D72B4EEDDD0083E63C /* SignUpPresenterTests.swift */; };
@@ -531,6 +532,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				194551FD2B0386D100299768 /* KakaoSDK in Frameworks */,
+				19AF2A062B5D06B9008C3620 /* HLSCachingServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1286,6 +1288,7 @@
 			name = Layover;
 			packageProductDependencies = (
 				194551FC2B0386D100299768 /* KakaoSDK */,
+				19AF2A052B5D06B9008C3620 /* HLSCachingServer */,
 			);
 			productName = Layover;
 			productReference = FC7E45362AFEB623004F155A /* Layover.app */;
@@ -1340,6 +1343,7 @@
 			mainGroup = FC7E452D2AFEB623004F155A;
 			packageReferences = (
 				194551FB2B03863B00299768 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				19AF2A042B5D06B9008C3620 /* XCRemoteSwiftPackageReference "HLSCachingServer" */,
 			);
 			productRefGroup = FC7E45372AFEB623004F155A /* Products */;
 			projectDirPath = "";
@@ -1943,6 +1947,14 @@
 				kind = branch;
 			};
 		};
+		19AF2A042B5D06B9008C3620 /* XCRemoteSwiftPackageReference "HLSCachingServer" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/loinsir/HLSCachingServer";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1950,6 +1962,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 194551FB2B03863B00299768 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDK;
+		};
+		19AF2A052B5D06B9008C3620 /* HLSCachingServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19AF2A042B5D06B9008C3620 /* XCRemoteSwiftPackageReference "HLSCachingServer" */;
+			productName = HLSCachingServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/Layover/Layover.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Layover/Layover.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/loinsir/HLSCachingServer",
       "state" : {
         "branch" : "main",
-        "revision" : "53a12e8b498e3c95f55fa837f3561db22eab88bb"
+        "revision" : "968a67456b32d1ec889c60b826fd85b2fd6add39"
       }
     },
     {

--- a/iOS/Layover/Layover.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Layover/Layover.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,12 +10,48 @@
       }
     },
     {
+      "identity" : "hlscachingserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loinsir/HLSCachingServer",
+      "state" : {
+        "branch" : "main",
+        "revision" : "53a12e8b498e3c95f55fa837f3561db22eab88bb"
+      }
+    },
+    {
       "identity" : "kakao-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
         "branch" : "master",
         "revision" : "5840447aabb9512d0ead90f672724e558731abc1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
+        "version" : "2.62.0"
       }
     }
   ],

--- a/iOS/Layover/Layover/AppDelegate.swift
+++ b/iOS/Layover/Layover/AppDelegate.swift
@@ -7,11 +7,12 @@
 
 import UIKit
 import KakaoSDKCommon
+import HLSCachingServer
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    private let hlsCachingServer = HLSCachingServer(urlSession: .shared, urlCache: .shared)
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
@@ -26,6 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setNavigationControllerAppearance()
         setTabBarAppearance()
+
+        hlsCachingServer.start(port: 12345)
 
         return true
     }

--- a/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
+++ b/iOS/Layover/Layover/Scenes/Playback/PlaybackView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import AVFoundation
+import HLSCachingServer
 
 final class PlaybackView: UIView {
 
@@ -106,7 +107,8 @@ final class PlaybackView: UIView {
     // MARK: Player Setting Method
 
     func addAVPlayer(url: URL) {
-        playerView.player = AVPlayer(url: url)
+        guard let reverseProxyURL = HLSCachingServer.reverseProxyURL(from: url) else { return }
+        playerView.player = AVPlayer(url: reverseProxyURL)
     }
 
     func getPlayerItemStatus() -> AVPlayerItem.Status? {


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
- HLS 세그먼트 캐싱을 적용했습니다.

#### 📌 변경 사항
- SPM 라이브러리 의존성 추가했고, 우선 재생화면에만 캐싱을 적용시켰습니다.
- AppDelegate에 앱 실행과 함께 프록시 서버 start하고, static 메서드로 url 변환해서 playeritem에 넣어주면 됩니다.

##### 📸 ScreenShot
<img width="1224" alt="image" src="https://github.com/boostcampwm2023/iOS09-Layover/assets/46420281/0eb4408e-aee0-404e-a8e6-1546a0d1d912">
로컬서버에서 ts 세그먼트 로드 할 때, 해당 세그먼트가 캐시에서 나오는지, 서비스 서버에서 가져온 것인지 로그를 찍도록 했습니다.
한번 시청한 동영상은 캐싱이 되는 것을 확인할 수 있습니다.

#### Linked Issue
close #346 
